### PR TITLE
LPS-67529

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceBlockLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceBlockLocalServiceImpl.java
@@ -428,6 +428,10 @@ public class ResourceBlockLocalServiceImpl
 	}
 
 	@Override
+	@Transactional(
+		isolation = Isolation.READ_COMMITTED,
+		propagation = Propagation.REQUIRES_NEW
+	)
 	public void releasePermissionedModelResourceBlock(String name, long primKey)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portal/verify/BaseVerifyResourceBlock.java
+++ b/portal-impl/src/com/liferay/portal/verify/BaseVerifyResourceBlock.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceBlockPermissionsContainer;
+import com.liferay.portal.kernel.service.ResourceTypePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.List;
+
+/**
+ * @author Preston Crary
+ */
+public abstract class BaseVerifyResourceBlock extends VerifyProcess {
+
+	@Override
+	protected void doVerify() {
+		List<String> modelNames = getModelNames();
+		List<String> tableNames = getTableNames();
+
+		for (int i = 0; i < tableNames.size(); i++) {
+			String modelName = modelNames.get(i);
+			String tableName = tableNames.get(i);
+
+			try (LoggingTimer loggingTimer = new LoggingTimer(tableName)) {
+				_addMissingResourceBlocks(tableName, modelName);
+
+				_correctResourceBlockReferenceCounts(tableName);
+			}
+			catch (Exception e) {
+				_log.error(
+					"Unable to verify ResourceBlocks for " + modelName, e);
+			}
+		}
+	}
+
+	protected abstract List<String> getModelNames();
+
+	protected abstract List<String> getTableNames();
+
+	private void _addMissingResourceBlocks(String tableName, String modelName)
+		throws SQLException {
+
+		StringBundler sb = new StringBundler(13);
+
+		sb.append("select t.companyId, t.groupId, t.resourceBlockId, ");
+		sb.append("t.referenceCount, ResourceBlockPermission.roleId, ");
+		sb.append("ResourceBlockPermission.actionIds from (select companyId, ");
+		sb.append("groupId, resourceBlockId, count(resourceBlockId) as ");
+		sb.append("referenceCount from ");
+		sb.append(tableName);
+		sb.append(" group by companyId, groupId, resourceBlockId) t left ");
+		sb.append("join ResourceBlock on (ResourceBlock.resourceBlockId = ");
+		sb.append("t.resourceBlockId) and (ResourceBlock.referenceCount != ");
+		sb.append("t.referenceCount) inner join ResourceBlockPermission on (");
+		sb.append("ResourceBlockPermission.resourceBlockId = ");
+		sb.append("t.resourceBlockId) where ResourceBlock.resourceBlockId is ");
+		sb.append("null");
+
+		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
+			ResultSet rs = ps.executeQuery();
+			PreparedStatement insertPS =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"insert into ResourceBlock (resourceBlockId, companyId, " +
+						"groupId, name, permissionsHash, referenceCount) " +
+							"values (?, ?, ?, ?, ?, ?)")) {
+
+			while (rs.next()) {
+				long companyId = rs.getLong(1);
+				long groupId = rs.getLong(2);
+				long resourceBlockId = rs.getLong(3);
+				long referenceCount = rs.getLong(4);
+				long roleId = rs.getLong(5);
+				long actionIds = rs.getLong(6);
+
+				ResourceBlockPermissionsContainer
+					resourceBlockPermissionsContainer =
+						ResourceTypePermissionLocalServiceUtil.
+							getResourceBlockPermissionsContainer(
+								companyId, groupId, modelName);
+
+				resourceBlockPermissionsContainer.setPermissions(
+					roleId, actionIds);
+
+				String permissionsHash =
+					resourceBlockPermissionsContainer.getPermissionsHash();
+
+				insertPS.setLong(1, resourceBlockId);
+				insertPS.setLong(2, companyId);
+				insertPS.setLong(3, groupId);
+				insertPS.setString(4, modelName);
+				insertPS.setString(5, permissionsHash);
+				insertPS.setLong(6, referenceCount);
+
+				insertPS.executeUpdate();
+			}
+		}
+	}
+
+	private void _correctResourceBlockReferenceCounts(String tableName)
+		throws SQLException {
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append("select t.resourceBlockId, t.referenceCount from (select ");
+		sb.append("companyId, groupId, resourceBlockId, ");
+		sb.append("count(resourceBlockId) as referenceCount from ");
+		sb.append(tableName);
+		sb.append(" group by companyId, groupId, resourceBlockId) t inner ");
+		sb.append("join ResourceBlock on (ResourceBlock.resourceBlockId = ");
+		sb.append("t.resourceBlockId) and (ResourceBlock.referenceCount ");
+		sb.append("!= t.referenceCount)");
+
+		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
+			ResultSet rs = ps.executeQuery();
+			PreparedStatement updatePS =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update ResourceBlock set referenceCount = ? where " +
+						"resourceBlockId = ?")) {
+
+			while (rs.next()) {
+				long resourceBlockId = rs.getLong(1);
+				long referenceCount = rs.getLong(2);
+
+				updatePS.setLong(1, referenceCount);
+				updatePS.setLong(2, resourceBlockId);
+
+				updatePS.executeUpdate();
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseVerifyResourceBlock.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -42,6 +42,7 @@ public class VerifyProcessSuite extends VerifyProcess {
 		verify(new VerifyOrganization());
 		verify(new VerifyRatings());
 		verify(new VerifyResourceActions());
+		verify(new VerifyResourceBlocks());
 		verify(new VerifyResourcePermissions());
 		verify(new VerifySocial());
 		verify(new VerifyUser());

--- a/portal-impl/src/com/liferay/portal/verify/VerifyResourceBlocks.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyResourceBlocks.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.ResourceBlock;
+import com.liferay.portal.kernel.model.ResourceBlockPermission;
+import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourceBlockLocalServiceUtil;
+import com.liferay.portal.kernel.util.CharPool;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Preston Crary
+ */
+public class VerifyResourceBlocks extends BaseVerifyResourceBlock {
+
+	@Override
+	protected void doVerify() {
+		List<ClassName> classNames = ClassNameLocalServiceUtil.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (ClassName className : classNames) {
+			String value = className.getValue();
+
+			if (ResourceBlockLocalServiceUtil.isSupported(value) &&
+				!value.equals(ResourceBlock.class.getName()) &&
+				!value.equals(ResourceBlockPermission.class.getName())) {
+
+				int pos = value.lastIndexOf(CharPool.PERIOD);
+
+				String tableName = value;
+
+				if (pos >= 0) {
+					tableName = value.substring(pos + 1);
+				}
+
+				try (PreparedStatement ps = connection.prepareStatement(
+						"select count(*) from " + tableName);
+					ResultSet rs = ps.executeQuery()) {
+
+					if (rs.next()) {
+						_modelNames.add(value);
+						_tableNames.add(tableName);
+					}
+				}
+				catch (SQLException sqle) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(sqle, sqle);
+					}
+				}
+			}
+		}
+
+		super.doVerify();
+	}
+
+	@Override
+	protected List<String> getModelNames() {
+		return _modelNames;
+	}
+
+	@Override
+	protected List<String> getTableNames() {
+		return _tableNames;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		VerifyResourceBlocks.class);
+
+	private final List<String> _modelNames = new ArrayList<>();
+	private final List<String> _tableNames = new ArrayList<>();
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/service/ResourceBlockLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/ResourceBlockLocalServiceTest.java
@@ -17,10 +17,18 @@ package com.liferay.portal.service;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.PermissionedModel;
+import com.liferay.portal.kernel.model.ResourceBlock;
 import com.liferay.portal.kernel.model.ResourceBlockPermissionsContainer;
 import com.liferay.portal.kernel.service.ResourceBlockLocalServiceUtil;
+import com.liferay.portal.kernel.service.persistence.ResourceBlockUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.transaction.Isolation;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionDefinition;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.test.rule.ExpectedDBType;
 import com.liferay.portal.test.rule.ExpectedLog;
 import com.liferay.portal.test.rule.ExpectedLogs;
@@ -286,6 +294,92 @@ public class ResourceBlockLocalServiceTest {
 			permissionedModel.getResourceBlockId(), _REFERENCE_COUNT);
 	}
 
+	@Test
+	public void testRollbackRelease() throws Throwable {
+		final PermissionedModel permissionedModel = new MockPermissionedModel();
+
+		ResourceBlockPermissionsContainer resourceBlockPermissionsContainer =
+			new ResourceBlockPermissionsContainer();
+
+		resourceBlockPermissionsContainer.addPermission(_ROLE_ID, _ACTION_IDS);
+
+		ResourceBlock resourceBlock =
+			ResourceBlockLocalServiceUtil.updateResourceBlockId(
+				_COMPANY_ID, _GROUP_ID, _MODEL_NAME, permissionedModel,
+				resourceBlockPermissionsContainer.getPermissionsHash(),
+				resourceBlockPermissionsContainer);
+
+		Assert.assertEquals(1, resourceBlock.getReferenceCount());
+
+		TransactionConfig transactionConfig = TransactionConfig.Factory.create(
+			Isolation.DEFAULT, Propagation.REQUIRED, false,
+			TransactionDefinition.TIMEOUT_DEFAULT,
+			new Class[] {SystemException.class},
+			new String[] {SystemException.class.getName()}, new Class[0],
+			StringPool.EMPTY_ARRAY);
+
+		try {
+			TransactionInvokerUtil.invoke(
+				transactionConfig,
+				new Callable<Void>() {
+
+					public Void call() throws Exception {
+						ResourceBlockLocalServiceUtil.
+							releasePermissionedModelResourceBlock(
+								permissionedModel);
+
+						throw new SystemException(
+							ResourceBlockLocalServiceTest.class.getName());
+					}
+
+				});
+		}
+		catch (SystemException se) {
+			Assert.assertEquals(
+				ResourceBlockLocalServiceTest.class.getName(), se.getMessage());
+		}
+
+		ResourceBlockUtil.clearCache(resourceBlock);
+
+		resourceBlock = ResourceBlockLocalServiceUtil.fetchResourceBlock(
+			resourceBlock.getResourceBlockId());
+
+		Assert.assertNotNull(resourceBlock);
+		Assert.assertEquals(1, resourceBlock.getReferenceCount());
+	}
+
+	@Test
+	public void testRollbackRetain() throws Throwable {
+		TransactionConfig transactionConfig = TransactionConfig.Factory.create(
+			Isolation.DEFAULT, Propagation.REQUIRED, false,
+			TransactionDefinition.TIMEOUT_DEFAULT,
+			new Class[] {SystemException.class},
+			new String[] {SystemException.class.getName()}, new Class[0],
+			StringPool.EMPTY_ARRAY);
+
+		TransactionRollbackCallable transactionRollbackCallable =
+			new TransactionRollbackCallable();
+
+		try {
+			TransactionInvokerUtil.invoke(
+				transactionConfig, transactionRollbackCallable);
+		}
+		catch (SystemException se) {
+			Assert.assertEquals(
+				ResourceBlockLocalServiceTest.class.getName(), se.getMessage());
+		}
+
+		ResourceBlock resourceBlock =
+			transactionRollbackCallable.getResourceBlock();
+
+		ResourceBlockUtil.clearCache(resourceBlock);
+
+		resourceBlock = ResourceBlockLocalServiceUtil.fetchResourceBlock(
+			resourceBlock.getResourceBlockId());
+
+		Assert.assertNull(resourceBlock);
+	}
+
 	private void _addResourceBlock(long resourceBlockId, long referenceCount)
 		throws Exception {
 
@@ -422,6 +516,36 @@ public class ResourceBlockLocalServiceTest {
 
 		private final PermissionedModel _permissionedModel;
 		private final Semaphore _semaphore;
+
+	}
+
+	private static class TransactionRollbackCallable implements Callable<Void> {
+
+		public Void call() throws Exception {
+			PermissionedModel permissionedModel = new MockPermissionedModel();
+
+			ResourceBlockPermissionsContainer
+				resourceBlockPermissionsContainer =
+					new ResourceBlockPermissionsContainer();
+
+			resourceBlockPermissionsContainer.addPermission(
+				_ROLE_ID, _ACTION_IDS);
+
+			_resourceBlock =
+				ResourceBlockLocalServiceUtil.updateResourceBlockId(
+					_COMPANY_ID, _GROUP_ID, _MODEL_NAME, permissionedModel,
+					resourceBlockPermissionsContainer.getPermissionsHash(),
+					resourceBlockPermissionsContainer);
+
+			throw new SystemException(
+				ResourceBlockLocalServiceTest.class.getName());
+		}
+
+		public ResourceBlock getResourceBlock() {
+			return _resourceBlock;
+		}
+
+		private ResourceBlock _resourceBlock;
 
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/verify/VerifyProcessSuiteTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/verify/VerifyProcessSuiteTest.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.verify;
 
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.verify.test.BaseVerifyProcessTestCase;
 
@@ -24,12 +26,15 @@ import org.junit.Rule;
 /**
  * @author Manuel de la Peña
  */
+@Sync
 public class VerifyProcessSuiteTest extends BaseVerifyProcessTestCase {
 
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Override
 	protected VerifyProcess getVerifyProcess() {

--- a/portal-impl/test/integration/com/liferay/portal/verify/VerifyResourceBlocksTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/verify/VerifyResourceBlocksTest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceBlockPermissionsContainer;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.service.ResourceTypePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.test.BaseVerifyProcessTestCase;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Preston Crary
+ */
+@Sync
+public class VerifyResourceBlocksTest extends BaseVerifyProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_runSQL(
+			"create table VerifyResourceBlocksTest (id LONG not null " +
+				"primary key, companyId LONG, groupId LONG, resourceBlockId " +
+					"LONG)");
+
+		_runSQL(
+			"insert into VerifyResourceBlocksTest values (1, " +
+				TestPropsValues.getCompanyId() + ", " +
+					TestPropsValues.getGroupId() + ", -1)");
+		_runSQL(
+			"insert into VerifyResourceBlocksTest values (2, " +
+				TestPropsValues.getCompanyId() + ", " +
+					TestPropsValues.getGroupId() + ", -2)");
+		_runSQL(
+			"insert into VerifyResourceBlocksTest values (3, " +
+				TestPropsValues.getCompanyId() + ", " +
+					TestPropsValues.getGroupId() + ", -2)");
+
+		_testRole = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_runSQL(
+			"insert into ResourceBlock (resourceBlockId, companyId, groupId, " +
+				"name, permissionsHash, referenceCount) values (-2, " +
+					TestPropsValues.getCompanyId() + ", " +
+						TestPropsValues.getGroupId() + ", '" + _modelName +
+							"', '" + _getPermissionHash(_actionIds2) + "', 1)");
+
+		_runSQL(
+			"insert into ResourceBlockPermission (resourceBlockPermissionId, " +
+				"companyId, resourceBlockId, roleId, actionIds) values (-1, " +
+					TestPropsValues.getCompanyId() + ", -1, " +
+						_testRole.getRoleId() + ", " + _actionIds1 + ")");
+		_runSQL(
+			"insert into ResourceBlockPermission (resourceBlockPermissionId, " +
+				"companyId, resourceBlockId, roleId, actionIds) values (-2, " +
+					TestPropsValues.getCompanyId() + ", -2, " +
+						_testRole.getRoleId() + ", " + _actionIds2 + ")");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_runSQL("drop table VerifyResourceBlocksTest");
+
+		_runSQL("delete from ResourceBlock where resourceBlockId < 0");
+		_runSQL(
+			"delete from ResourceBlockPermission where resourceBlockId < 0");
+	}
+
+	@Test
+	public void testAddMissingResourceBlocks() throws Exception {
+		_assertResourceBlocks(-1, _actionIds1, 1);
+	}
+
+	@Test
+	public void testCorrectResourceBlockReferenceCounts() throws Exception {
+		_assertResourceBlocks(-2, _actionIds2, 2);
+	}
+
+	@Test
+	public void testGetModelAndTableNames() throws Exception {
+		VerifyResourceBlocks verifyResourceBlocks = new VerifyResourceBlocks();
+
+		verifyResourceBlocks.verify();
+
+		List<String> modelNames = verifyResourceBlocks.getModelNames();
+		List<String> tableNames = verifyResourceBlocks.getTableNames();
+
+		Assert.assertEquals(modelNames.size(), tableNames.size());
+
+		Assert.assertEquals(_expectedModelNames.size(), modelNames.size());
+		Assert.assertTrue(_expectedModelNames.containsAll(modelNames));
+
+		Assert.assertEquals(_expectedTableNames.size(), tableNames.size());
+		Assert.assertTrue(_expectedTableNames.containsAll(tableNames));
+	}
+
+	@Override
+	protected VerifyProcess getVerifyProcess() {
+		return _verifyProcess;
+	}
+
+	private void _assertResourceBlocks(
+			long resourceBlockId, long actionIds, long expectedReferenceCount)
+		throws Exception {
+
+		doVerify();
+
+		String permissionHash = _getPermissionHash(actionIds);
+
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps = con.prepareStatement(
+				"select * from ResourceBlock where resourceBlockId = " +
+					resourceBlockId);
+			ResultSet rs = ps.executeQuery()) {
+
+			Assert.assertTrue(rs.next());
+			Assert.assertEquals(
+				TestPropsValues.getCompanyId(), rs.getLong("companyId"));
+			Assert.assertEquals(
+				TestPropsValues.getGroupId(), rs.getLong("groupId"));
+			Assert.assertEquals(
+				permissionHash, rs.getString("permissionsHash"));
+			Assert.assertEquals(
+				expectedReferenceCount, rs.getLong("referenceCount"));
+		}
+	}
+
+	private String _getPermissionHash(long actionIds) throws PortalException {
+		ResourceBlockPermissionsContainer resourceBlockPermissionsContainer =
+			ResourceTypePermissionLocalServiceUtil.
+				getResourceBlockPermissionsContainer(
+					TestPropsValues.getCompanyId(),
+					TestPropsValues.getGroupId(), _modelName);
+
+		resourceBlockPermissionsContainer.setPermissions(
+			_testRole.getRoleId(), actionIds);
+
+		return resourceBlockPermissionsContainer.getPermissionsHash();
+	}
+
+	private void _runSQL(String sql) throws Exception {
+		_verifyProcess.runSQL(sql);
+	}
+
+	private static final long _actionIds1 = 2L;
+	private static final long _actionIds2 = 6L;
+	private static final List<String> _expectedModelNames = Arrays.asList(
+		"com.liferay.calendar.model.Calendar",
+		"com.liferay.calendar.model.CalendarBooking",
+		"com.liferay.calendar.model.CalendarResource",
+		"com.liferay.bookmarks.model.BookmarksEntry",
+		"com.liferay.bookmarks.model.BookmarksFolder");
+	private static final List<String> _expectedTableNames = Arrays.asList(
+		"Calendar", "CalendarBooking", "CalendarResource", "BookmarksEntry",
+		"BookmarksFolder");
+	private static final String _modelName =
+		VerifyResourceBlocksTest.class.getName();
+	private static final VerifyProcess _verifyProcess =
+		new TestVerifyResourceBlock();
+
+	@DeleteAfterTestRun
+	private Role _testRole;
+
+	private static class TestVerifyResourceBlock
+		extends BaseVerifyResourceBlock {
+
+		protected List<String> getModelNames() {
+			return Collections.singletonList(_modelName);
+		}
+
+		protected List<String> getTableNames() {
+			return Collections.singletonList("VerifyResourceBlocksTest");
+		}
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourceBlockLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourceBlockLocalService.java
@@ -343,6 +343,7 @@ public interface ResourceBlockLocalService extends BaseLocalService,
 	public void releasePermissionedModelResourceBlock(
 		PermissionedModel permissionedModel);
 
+	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 	public void releasePermissionedModelResourceBlock(java.lang.String name,
 		long primKey) throws PortalException;
 


### PR DESCRIPTION
Can you update this to fix the issues you found with the verify, it can be like the one you had 06d2164 but I want to use new the queries.  We also want to update the verify to delete any ResourceBlocks with 0 referenceCounts, just use runSQL for that near the end of the verify.

The new plan is to only delete ResourceBlocks in the verify, removing the problem with transaction rollbacks.  Can you also make this change?  It means we can remove that while true block in the local service as well.

I would do it but it'll be a long time before I can spend the time needed to make these changes.

Let me know if you have questions, thanks!
