### PR TITLE
LPS-76807 Using fileShortcutId to lock/unlock entry

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -97,12 +97,35 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 		long[] fileEntryIds = ParamUtil.getLongValues(
 			actionRequest, "rowIdsFileEntry");
 
+		long[] fileShortcutIds = ParamUtil.getLongValues(
+			actionRequest, "rowIdsDLFileShortcut");
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		for (long fileEntryId : fileEntryIds) {
 			_dlAppService.checkInFileEntry(
 				fileEntryId, false, StringPool.BLANK, serviceContext);
+		}
+
+		for (long fileShortcutId : fileShortcutIds)
+		{
+			boolean flag = true;
+			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
+				fileShortcutId);
+
+			long toFileEntryId = fileShortcut.getToFileEntryId();
+
+			for (long fileEntryId : fileEntryIds) {
+				if (toFileEntryId == fileEntryId) {
+					flag = false;
+				}
+			}
+
+			if (flag == true) {
+				_dlAppService.checkInFileEntry(
+					toFileEntryId, false, StringPool.BLANK, serviceContext);
+			}
 		}
 	}
 
@@ -112,11 +135,34 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 		long[] fileEntryIds = ParamUtil.getLongValues(
 			actionRequest, "rowIdsFileEntry");
 
+		long[] fileShortcutIds = ParamUtil.getLongValues(
+			actionRequest, "rowIdsDLFileShortcut");
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		for (long fileEntryId : fileEntryIds) {
 			_dlAppService.checkOutFileEntry(fileEntryId, serviceContext);
+		}
+
+		for (long fileShortcutId : fileShortcutIds)
+		{
+			boolean flag = true;
+
+			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
+				fileShortcutId);
+
+			long toFileEntryId = fileShortcut.getToFileEntryId();
+
+			for (long fileEntryId : fileEntryIds) {
+				if (toFileEntryId == fileEntryId) {
+					flag = false;
+				}
+			}
+
+			if (flag == true) {
+				_dlAppService.checkOutFileEntry(toFileEntryId, serviceContext);
+			}
 		}
 	}
 


### PR DESCRIPTION
The Lock/Unlock icon doesn't work on shortcut, because the original fileEntryId can not be got through actionRequest. So I add the follow code, using the fileShortcutId to get the FileShortcut object, then using getToFileEntryId method to get the toFileEntryId which is related to the original file. Now we can lock or unlock the file by using the toFileEntryId. (the toFileEntryId is same with the fileEntryId of the original file)