### PR TITLE
Lps 76807 LPS-76807 Using fileShortcutId to lock/unlock entry

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -97,12 +97,35 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 		long[] fileEntryIds = ParamUtil.getLongValues(
 			actionRequest, "rowIdsFileEntry");
 
+		long[] fileShortcutIds = ParamUtil.getLongValues(
+			actionRequest, "rowIdsDLFileShortcut");
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		for (long fileEntryId : fileEntryIds) {
 			_dlAppService.checkInFileEntry(
 				fileEntryId, false, StringPool.BLANK, serviceContext);
+		}
+
+		for (long fileShortcutId : fileShortcutIds)
+		{
+			boolean flag = true;
+			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
+				fileShortcutId);
+
+			long toFileEntryId = fileShortcut.getToFileEntryId();
+
+			for (long fileEntryId : fileEntryIds) {
+				if (toFileEntryId == fileEntryId) {
+					flag = false;
+				}
+			}
+
+			if (flag == true) {
+				_dlAppService.checkInFileEntry(
+					toFileEntryId, false, StringPool.BLANK, serviceContext);
+			}
 		}
 	}
 
@@ -112,11 +135,34 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 		long[] fileEntryIds = ParamUtil.getLongValues(
 			actionRequest, "rowIdsFileEntry");
 
+		long[] fileShortcutIds = ParamUtil.getLongValues(
+			actionRequest, "rowIdsDLFileShortcut");
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		for (long fileEntryId : fileEntryIds) {
 			_dlAppService.checkOutFileEntry(fileEntryId, serviceContext);
+		}
+
+		for (long fileShortcutId : fileShortcutIds)
+		{
+			boolean flag = true;
+
+			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
+				fileShortcutId);
+
+			long toFileEntryId = fileShortcut.getToFileEntryId();
+
+			for (long fileEntryId : fileEntryIds) {
+				if (toFileEntryId == fileEntryId) {
+					flag = false;
+				}
+			}
+
+			if (flag == true) {
+				_dlAppService.checkOutFileEntry(toFileEntryId, serviceContext);
+			}
 		}
 	}
 

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.ServletResponseConstants;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -108,21 +109,17 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 				fileEntryId, false, StringPool.BLANK, serviceContext);
 		}
 
-		for (long fileShortcutId : fileShortcutIds)
-		{
-			boolean flag = true;
+		for (long fileShortcutId : fileShortcutIds) {
+			boolean flag = false;
+
 			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
 				fileShortcutId);
 
 			long toFileEntryId = fileShortcut.getToFileEntryId();
 
-			for (long fileEntryId : fileEntryIds) {
-				if (toFileEntryId == fileEntryId) {
-					flag = false;
-				}
-			}
+			flag = ArrayUtil.contains(fileEntryIds, toFileEntryId);
 
-			if (flag == true) {
+			if (flag == false) {
 				_dlAppService.checkInFileEntry(
 					toFileEntryId, false, StringPool.BLANK, serviceContext);
 			}
@@ -145,22 +142,17 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 			_dlAppService.checkOutFileEntry(fileEntryId, serviceContext);
 		}
 
-		for (long fileShortcutId : fileShortcutIds)
-		{
-			boolean flag = true;
+		for (long fileShortcutId : fileShortcutIds) {
+			boolean flag = false;
 
 			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
 				fileShortcutId);
 
 			long toFileEntryId = fileShortcut.getToFileEntryId();
 
-			for (long fileEntryId : fileEntryIds) {
-				if (toFileEntryId == fileEntryId) {
-					flag = false;
-				}
-			}
+			flag = ArrayUtil.contains(fileEntryIds, toFileEntryId);
 
-			if (flag == true) {
+			if (flag == false) {
 				_dlAppService.checkOutFileEntry(toFileEntryId, serviceContext);
 			}
 		}


### PR DESCRIPTION
The Lock/Unlock icon doesn't work on shortcut, because the original fileEntryId can not be got through actionRequest. So I add the follow code, using the fileShortcutId to get the FileShortcut object, then using getToFileEntryId method to get the toFileEntryId which is related to the original file. Now we can lock or unlock the file by using the toFileEntryId. (the toFileEntryId is same with the fileEntryId of the original file)
I replaced the for-loop with ArrayUtil.cantains( ).