### PR TITLE
Lps 76937 Liferay Social Networking Requests Portlet throws unexpected error

### DIFF
--- a/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
+++ b/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
@@ -432,7 +432,12 @@ public class ContactsCenterPortlet extends MVCPortlet {
 
 			JSONObject extraDataJSONObject = JSONFactoryUtil.createJSONObject();
 
-			String portletId = portal.getPortletId(actionRequest);
+			String portletId = PortletIdCodec.decodePortletName(
+				portal.getPortletId(actionRequest));
+
+			if (portletId.equals(ContactsPortletKeys.PROFILE)) {
+				portletId = ContactsPortletKeys.CONTACTS_CENTER;
+			}
 
 			extraDataJSONObject.put(
 				"portletId", PortletIdCodec.decodePortletName(portletId));

--- a/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/social/ContactsCenterRequestInterpreter.java
+++ b/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/social/ContactsCenterRequestInterpreter.java
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Hai Yu
  */
 @Component(
-	property = {"javax.portlet.name=" + ContactsPortletKeys.PROFILE},
+	property = {"javax.portlet.name=" + ContactsPortletKeys.CONTACTS_CENTER},
 	service = SocialRequestInterpreter.class
 )
 public class ContactsCenterRequestInterpreter

--- a/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/social/ContactsCenterRequestInterpreter.java
+++ b/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/social/ContactsCenterRequestInterpreter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.contacts.web.internal.social;
 
+import com.liferay.contacts.web.internal.constants.ContactsPortletKeys;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -25,14 +26,20 @@ import com.liferay.social.kernel.model.BaseSocialRequestInterpreter;
 import com.liferay.social.kernel.model.SocialRelationConstants;
 import com.liferay.social.kernel.model.SocialRequest;
 import com.liferay.social.kernel.model.SocialRequestFeedEntry;
+import com.liferay.social.kernel.model.SocialRequestInterpreter;
 import com.liferay.social.kernel.service.SocialActivityLocalService;
 import com.liferay.social.kernel.service.SocialRelationLocalService;
 
+import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Hai Yu
  */
+@Component(
+	property = {"javax.portlet.name=" + ContactsPortletKeys.PROFILE},
+	service = SocialRequestInterpreter.class
+)
 public class ContactsCenterRequestInterpreter
 	extends BaseSocialRequestInterpreter {
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -3883,6 +3883,7 @@ request-holiday=Request Holiday
 request-is-larger-than-x-and-could-not-be-processed=Request is larger than {0} and could not be processed.
 request-pending=Request Pending
 request-social-networking-summary-add-friend={0} wants to be your friend.
+request-social-networking-summary-add-connection={0} would like to add you as a connection.
 request-social-networking-summary-join-organization={0} wants to join {1}.
 request-timeout=Request Timeout
 requests=Requests


### PR DESCRIPTION
Last time, I just add the ContactsCenterRequestInterpreter to be a service, and change the key to be the ProfilePortlet's key. It is not correct. So this time I change the ProfilePortletId to be ContactCenterPortletId when add it to the Request. Because the ProfilePotlet is a child class of ContactCenterPortlet. they use a same interpret is reasonable. 