### PR TITLE
LPS-76934 File cannot be removed in Multiple Documents in IE 11

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_uploader.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_uploader.scss
@@ -141,7 +141,7 @@
 		}
 
 		.delete-button {
-			display: inline;
+			display: inline-block;
 		}
 	}
 


### PR DESCRIPTION
For this issue, I changed the _uploader.sccs file, because it is the last layer of style sheep to influence the .delete-button. I changed the inline to inline-block for display. Because there is a <svg> tag in a inline display, but it needs a block behavior. At that time we need inline-block for display.