### PR TITLE
LPS-77596 Can't see the title of the search portlet.

### DIFF
--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/display/context/PortletConfigurationCSSPortletDisplayContext.java
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/display/context/PortletConfigurationCSSPortletDisplayContext.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletDecorator;
 import com.liferay.portal.kernel.model.Theme;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletSetupUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
@@ -75,7 +74,7 @@ public class PortletConfigurationCSSPortletDisplayContext {
 			renderRequest, "portletResource");
 
 		PortletPreferences portletSetup =
-			PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup(
+			themeDisplay.getStrictLayoutPortletSetup(
 				themeDisplay.getLayout(), portletResource);
 
 		JSONObject portletSetupJSONObject = PortletSetupUtil.cssToJSONObject(


### PR DESCRIPTION
The real problem is that the title and other values can't be correctly displayed on the look and feel configuration page. 
The page always display the default value, because when saving these configurations, these data is stored in one record in database and reading data from another record. I found when reading data, it uses PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup() method and uses themeDisplay.getStrictLayoutPortletSetup() to write date. The differences is they got the different plid and ownerId. My solution is change PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup() to themeDisplay.getStrictLayoutPortletSetup()  to keep them consistent.