### PR TITLE
LPS-80957 Using unitSet to validator the attributes

### DIFF
--- a/portal-web/docroot/html/common/themes/portlet_css.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_css.jspf
@@ -91,8 +91,10 @@ String borderRightColorValue = borderColor.getString(_RIGHT_KEY);
 String borderBottomColorValue = borderColor.getString(_BOTTOM_KEY);
 String borderLeftColorValue = borderColor.getString(_LEFT_KEY);
 
-if (ufaBorderWidth && !_unitSet.contains(borderTopWidthValue)) {
-	finalCSS.add("border-width: " + borderTopWidthValue);
+if (ufaBorderWidth){
+	if (!_unitSet.contains(borderTopWidthValue)) {
+		finalCSS.add("border-width: " + borderTopWidthValue);
+	}
 }
 else {
 	if (!_unitSet.contains(borderTopWidthValue)) {
@@ -112,8 +114,10 @@ else {
 	}
 }
 
-if (ufaBorderStyle && !_unitSet.contains(borderTopWidthValue)) {
-	finalCSS.add("border-style: " + borderTopStyleValue);
+if (ufaBorderStyle){
+	if (!_unitSet.contains(borderTopWidthValue)) {
+		finalCSS.add("border-style: " + borderTopStyleValue);
+	}
 }
 else {
 	if (Validator.isNotNull(borderTopStyleValue)) {
@@ -178,8 +182,10 @@ String marginRightValue = marginRight.getString(_VALUE_KEY) + marginRight.getStr
 String marginBottomValue = marginBottom.getString(_VALUE_KEY) + marginBottom.getString(_UNIT_KEY);
 String marginLeftValue = marginLeft.getString(_VALUE_KEY) + marginLeft.getString(_UNIT_KEY);
 
-if (ufaMargin && !_unitSet.contains(marginTopValue)) {
-	finalCSS.add("margin: " + marginTopValue);
+if (ufaMargin){
+	if (!_unitSet.contains(marginTopValue)) {
+		finalCSS.add("margin: " + marginTopValue);
+	}
 }
 else {
 	if (!_unitSet.contains(marginTopValue)) {
@@ -211,8 +217,10 @@ String paddingRightValue = paddingRight.getString(_VALUE_KEY) + paddingRight.get
 String paddingBottomValue = paddingBottom.getString(_VALUE_KEY) + paddingBottom.getString(_UNIT_KEY);
 String paddingLeftValue = paddingLeft.getString(_VALUE_KEY) + paddingLeft.getString(_UNIT_KEY);
 
-if (ufaPadding && !_unitSet.contains(paddingTopValue)) {
-	finalCSS.add("padding: " + paddingTopValue);
+if (ufaPadding){
+	if (!_unitSet.contains(paddingTopValue)) {
+		finalCSS.add("padding: " + paddingTopValue);
+	}
 }
 else {
 	if (!_unitSet.contains(paddingTopValue)) {

--- a/portal-web/docroot/html/common/themes/portlet_css.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_css.jspf
@@ -72,21 +72,10 @@ String borderRightWidthValue = StringPool.BLANK;
 String borderBottomWidthValue = StringPool.BLANK;
 String borderLeftWidthValue = StringPool.BLANK;
 
-if (Validator.isNotNull(borderWidthTop.getString(_VALUE_KEY))) {
-	borderTopWidthValue = borderWidthTop.getString(_VALUE_KEY) + borderWidthTop.getString(_UNIT_KEY);
-}
-
-if (Validator.isNotNull(borderWidthRight.getString(_VALUE_KEY))) {
-	borderRightWidthValue = borderWidthRight.getString(_VALUE_KEY) + borderWidthRight.getString(_UNIT_KEY);
-}
-
-if (Validator.isNotNull(borderWidthBottom.getString(_VALUE_KEY))) {
-	borderBottomWidthValue = borderWidthBottom.getString(_VALUE_KEY) + borderWidthBottom.getString(_UNIT_KEY);
-}
-
-if (Validator.isNotNull(borderWidthLeft.getString(_VALUE_KEY))) {
-	borderLeftWidthValue = borderWidthLeft.getString(_VALUE_KEY) + borderWidthLeft.getString(_UNIT_KEY);
-}
+borderTopWidthValue = borderWidthTop.getString(_VALUE_KEY) + borderWidthTop.getString(_UNIT_KEY);
+borderRightWidthValue = borderWidthRight.getString(_VALUE_KEY) + borderWidthRight.getString(_UNIT_KEY);
+borderBottomWidthValue = borderWidthBottom.getString(_VALUE_KEY) + borderWidthBottom.getString(_UNIT_KEY);
+borderLeftWidthValue = borderWidthLeft.getString(_VALUE_KEY) + borderWidthLeft.getString(_UNIT_KEY);
 
 // Style
 


### PR DESCRIPTION
Reason: For this issue, invalid css like "border-width:;border-style:" is displayed in source view, that because user didn't give any value for these styles. And the default value of them is "blank". When the ufaBorderWidth and ufaBorderStyle are false, the value shouldn't be null, the value should have "unit" follow.

Solution: My solution is using unitset to check, if the value is null, then this attribute will not be added to final CSS.