### PR TITLE
LPS-81154 Get the LanguageIds by PrefsPropsUtil.getStringArray() method

### DIFF
--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/internal/display/context/SiteNavigationLanguageDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/internal/display/context/SiteNavigationLanguageDisplayContext.java
@@ -14,7 +14,7 @@
 
 package com.liferay.site.navigation.language.web.internal.display.context;
 
-import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -23,9 +23,12 @@ import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.KeyValuePairComparator;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PrefsPropsUtil;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.display.template.PortletDisplayTemplate;
 import com.liferay.site.navigation.language.web.configuration.SiteNavigationLanguagePortletInstanceConfiguration;
 
@@ -90,8 +93,9 @@ public class SiteNavigationLanguageDisplayContext {
 			return _availableLanguageIds;
 		}
 
-		_availableLanguageIds = LocaleUtil.toLanguageIds(
-			LanguageUtil.getAvailableLocales(_themeDisplay.getSiteGroupId()));
+		_availableLanguageIds = PrefsPropsUtil.getStringArray(_themeDisplay.getCompanyId(),
+				PropsKeys.LOCALES, StringPool.COMMA,
+				PropsValues.LOCALES_ENABLED);
 
 		return _availableLanguageIds;
 	}


### PR DESCRIPTION
Reason: Changing the order of language setting is not reflected in Language Selector portlet (National flag icon). It's because when display the language, we got languageIds by two different ways. This issue can be reproduced on 7.0.x and master, but the it don't happen on 6.2.x, but I can't use the way in 6.2.x, so I made a unique fix.

Solution: When display the language items on Language Selector, I use the PrefsPropsUtil.getStringArray() method to get languageIds, it's the same way as the dispaly-settings used.