### PR TITLE
LPS-81154 Using LinkedHashMap replace HashMap

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1970,7 +1970,7 @@ public class LanguageImpl implements Language, Serializable {
 			}
 
 			_availableLocales = Collections.unmodifiableSet(
-				new HashSet<>(_languageIdLocalesMap.values()));
+				new LinkedHashSet<>(_languageIdLocalesMap.values()));
 
 			Set<Locale> supportedLocalesSet = new HashSet<>(
 				_languageIdLocalesMap.values());
@@ -1984,9 +1984,9 @@ public class LanguageImpl implements Language, Serializable {
 		private final Set<Locale> _availableLocales;
 		private final Set<String> _duplicateLanguageCodes;
 		private final Map<String, Locale> _languageCodeLocalesMap =
-			new HashMap<>();
+			new LinkedHashMap<>();
 		private final Map<String, Locale> _languageIdLocalesMap =
-			new HashMap<>();
+			new LinkedHashMap<>();
 		private final Set<Locale> _localesBetaSet = new HashSet<>();
 		private final Set<Locale> _supportedLocalesSet;
 

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -65,6 +65,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -979,7 +981,7 @@ public class LanguageImpl implements Language, Serializable {
 		Map<String, Locale> groupLanguageIdLocalesMap =
 			_getGroupLanguageIdLocalesMap(groupId);
 
-		return new HashSet<>(groupLanguageIdLocalesMap.values());
+		return new LinkedHashSet<>(groupLanguageIdLocalesMap.values());
 	}
 
 	@Override
@@ -1632,8 +1634,10 @@ public class LanguageImpl implements Language, Serializable {
 		catch (Exception e) {
 		}
 
-		HashMap<String, Locale> groupLanguageCodeLocalesMap = new HashMap<>();
-		HashMap<String, Locale> groupLanguageIdLocalesMap = new HashMap<>();
+		LinkedHashMap<String, Locale> groupLanguageCodeLocalesMap =
+			new LinkedHashMap<>();
+		LinkedHashMap<String, Locale> groupLanguageIdLocalesMap =
+			new LinkedHashMap<>();
 
 		for (String languageId : languageIds) {
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);


### PR DESCRIPTION
Reason: Changing the order of language setting is not reflected in Language Selector portlet (National flag icon). It's because we store languageIds by HashMap, and HashMap don't have order. This issue can be reproduced on 7.0.x and master, but the it don't happen on 6.2.x, because 6.2.x uses Array to store, but I can't use the way in 6.2.x, so I made a unique fix.

Solution: When display the language items on Language Selector, I use the LinkedHashMap replase HashMap to store languageIds. And here we should make the order same as Site Setting's order rather than Instance Setting's order if user don't use default language option. Because Sit Setting affect the language selector directly.