### PR TITLE
LPS-84503 After changing instance name, then changing current localizations in Instance Settings, localization validation error appears

### DIFF
--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/display_settings.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/display_settings.jsp
@@ -73,10 +73,8 @@
 
 		List leftList = new ArrayList();
 
-		String[] currentLanguageIds = PrefsPropsUtil.getStringArray(company.getCompanyId(), PropsKeys.LOCALES, StringPool.COMMA, PropsValues.LOCALES_ENABLED);
-
-		for (Locale currentLocale : LocaleUtil.fromLanguageIds(currentLanguageIds)) {
-			leftList.add(new KeyValuePair(LanguageUtil.getLanguageId(currentLocale), currentLocale.getDisplayName(locale)));
+		for (Locale availableLocale : LanguageUtil.getAvailableLocales()) {
+			leftList.add(new KeyValuePair(LocaleUtil.toLanguageId(availableLocale), availableLocale.getDisplayName(locale)));
 		}
 
 		// Right list

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/display_settings.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/display_settings.jsp
@@ -147,17 +147,8 @@ if (publicLayoutSet.isLayoutSetPrototypeLinkEnabled() || privateLayoutSet.isLayo
 
 		List leftList = new ArrayList();
 
-		String groupLanguageIds = typeSettingsProperties.getProperty(PropsKeys.LOCALES);
-
-		if (groupLanguageIds != null) {
-			for (Locale currentLocale : LocaleUtil.fromLanguageIds(StringUtil.split(groupLanguageIds))) {
-				leftList.add(new KeyValuePair(LanguageUtil.getLanguageId(currentLocale), currentLocale.getDisplayName(locale)));
-			}
-		}
-		else {
-			for (Locale siteAvailableLocale : siteAvailableLocales) {
-				leftList.add(new KeyValuePair(LocaleUtil.toLanguageId(siteAvailableLocale), siteAvailableLocale.getDisplayName(locale)));
-			}
+		for (Locale siteAvailableLocale : siteAvailableLocales) {
+			leftList.add(new KeyValuePair(LocaleUtil.toLanguageId(siteAvailableLocale), siteAvailableLocale.getDisplayName(locale)));
 		}
 
 		// Right list


### PR DESCRIPTION
Hi Hai,

I found this issue is caused by the fix of LPS-70517.(https://issues.liferay.com/browse/LPS-70517) That fix tried to save the languages by order, so he use type setting to save languages instead of LanguageUtil.
Actually, I have fix the order issue on LPS-81154 by  using LinkHashSet replace HashSet. Please refer: 
https://issues.liferay.com/browse/LPS-81154
So I think the fix of LPS-70517 is useless, in addition, it cause other issues, So I decided to delete the fix of LPS-70517 and using the original way to save the languages.

Br,
Seiphon