### PR TITLE
LPS 144437

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/embedded/test/EmbeddedPortletWhenEmbeddingPortletUsingRuntimeTagTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/embedded/test/EmbeddedPortletWhenEmbeddingPortletUsingRuntimeTagTest.java
@@ -212,11 +212,11 @@ public class EmbeddedPortletWhenEmbeddingPortletUsingRuntimeTagTest
 					).build()
 				).buildString());
 
-		long count = _portletPreferencesLocalService.getPortletPreferencesCount(
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
-			testRuntimePortletId);
-
-		Assert.assertTrue("portletPreferences count should be 0", count == 0);
+		Assert.assertEquals(
+			"portletPreferences count should be 0", 0,
+			_portletPreferencesLocalService.getPortletPreferencesCount(
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				testRuntimePortletId));
 
 		Assert.assertEquals(200, response.getCode());
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/resources/META-INF/resources/runtime_portlet.jsp
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/resources/META-INF/resources/runtime_portlet.jsp
@@ -24,5 +24,6 @@ String portletName = ParamUtil.getString(request, "testRuntimePortletId");
 %>
 
 <liferay-portlet:runtime
+	persistSettings='<%= ParamUtil.getBoolean(request, "persistSettings", true) %>'
 	portletName='<%= Validator.isBlank(portletName) ? (String)request.getAttribute("testRuntimePortletId") : portletName %>'
 />

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/resources/META-INF/resources/runtime_portlet.jsp
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/resources/META-INF/resources/runtime_portlet.jsp
@@ -16,14 +16,9 @@
 
 <%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
 
-<%@ page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.Validator" %>
-
-<%
-String portletName = ParamUtil.getString(request, "testRuntimePortletId");
-%>
+<%@ page import="com.liferay.portal.kernel.util.ParamUtil" %>
 
 <liferay-portlet:runtime
 	persistSettings='<%= ParamUtil.getBoolean(request, "persistSettings", true) %>'
-	portletName='<%= Validator.isBlank(portletName) ? (String)request.getAttribute("testRuntimePortletId") : portletName %>'
+	portletName='<%= ParamUtil.getString(request, "testRuntimePortletId", (String)request.getAttribute("testRuntimePortletId")) %>'
 />

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -309,12 +309,6 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 					PortletKeys.PREFS_PLID_SHARED, portletInstanceKey,
 					defaultPreferences);
 
-				writeObject = true;
-			}
-
-			if (!layout.isPortletEmbedded(
-					portlet.getPortletId(), layout.getGroupId())) {
-
 				long count =
 					PortletPreferencesLocalServiceUtil.
 						getPortletPreferencesCount(
@@ -335,9 +329,9 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 						portletLayoutListener.onAddToLayout(
 							portletInstanceKey, themeDisplay.getPlid());
 					}
-
-					writeObject = true;
 				}
+
+				writeObject = true;
 			}
 
 			if (writeObject) {

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -312,26 +312,32 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 				writeObject = true;
 			}
 
-			long count =
-				PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, themeDisplay.getPlid(),
-					portletInstanceKey);
+			if (!layout.isPortletEmbedded(
+					portlet.getPortletId(), layout.getGroupId())) {
 
-			if (count < 1) {
-				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-					layout, portletInstanceKey, defaultPreferences);
-				PortletPreferencesFactoryUtil.getPortletSetup(
-					httpServletRequest, portletInstanceKey, defaultPreferences);
+				long count =
+					PortletPreferencesLocalServiceUtil.
+						getPortletPreferencesCount(
+							PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+							themeDisplay.getPlid(), portletInstanceKey);
 
-				PortletLayoutListener portletLayoutListener =
-					portlet.getPortletLayoutListenerInstance();
+				if (count < 1) {
+					PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+						layout, portletInstanceKey, defaultPreferences);
+					PortletPreferencesFactoryUtil.getPortletSetup(
+						httpServletRequest, portletInstanceKey,
+						defaultPreferences);
 
-				if (portletLayoutListener != null) {
-					portletLayoutListener.onAddToLayout(
-						portletInstanceKey, themeDisplay.getPlid());
+					PortletLayoutListener portletLayoutListener =
+						portlet.getPortletLayoutListenerInstance();
+
+					if (portletLayoutListener != null) {
+						portletLayoutListener.onAddToLayout(
+							portletInstanceKey, themeDisplay.getPlid());
+					}
+
+					writeObject = true;
 				}
-
-				writeObject = true;
 			}
 
 			if (writeObject) {


### PR DESCRIPTION
- LPS-144437 Expose the issue. When persistSettings of RuntimeTag is false, we shouldn't save portletName related portletPreferences data to portletpreferences table.
- LPS-144437 SF, prepare for next commit.Because in layout.isPortletEmbedded(), the first assert portletPreferences is notNull, that means count >= 1.  When layout.isPortletEmbedded() retrun true, the count must be >= 1. The commit doesn't change the original logic.
- LPS-144437 Fix the issue. When persistSettings is false, no need to do portletPreferences related logic.
- LPS-144437 SF.
- LPS-144437 SF, use assertEquals
