### PR TITLE
[TS] LPS-146970 Move the message bus initializations from BackgroundTaskManager to a MessagingConfigurator class

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
@@ -30,13 +30,11 @@ import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.messaging.Destination;
-import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ClassUtil;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.io.File;
@@ -45,17 +43,12 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Dictionary;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -606,11 +599,8 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
-
-		Destination backgroundTaskDestination = _registerDestination(
-			bundleContext, DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
-			DestinationNames.BACKGROUND_TASK, 5, 10);
+		Destination backgroundTaskDestination = _messageBus.getDestination(
+			DestinationNames.BACKGROUND_TASK);
 
 		BackgroundTaskMessageListener backgroundTaskMessageListener =
 			new BackgroundTaskMessageListener(
@@ -620,9 +610,8 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 		backgroundTaskDestination.register(backgroundTaskMessageListener);
 
-		Destination backgroundTaskStatusDestination = _registerDestination(
-			bundleContext, DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-			DestinationNames.BACKGROUND_TASK_STATUS, 1, 1);
+		Destination backgroundTaskStatusDestination =
+			_messageBus.getDestination(DestinationNames.BACKGROUND_TASK_STATUS);
 
 		BackgroundTaskQueuingMessageListener
 			backgroundTaskQueuingMessageListener =
@@ -645,51 +634,8 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 		}
 	}
 
-	@Deactivate
-	protected void deactivate() {
-		for (ServiceRegistration<Destination> serviceRegistration :
-				_serviceRegistrations) {
-
-			Destination destination = _bundleContext.getService(
-				serviceRegistration.getReference());
-
-			serviceRegistration.unregister();
-
-			destination.destroy();
-		}
-
-		_bundleContext = null;
-	}
-
 	@Reference(unbind = "-")
 	protected void setLockManager(LockManager lockManager) {
-	}
-
-	private Destination _registerDestination(
-		BundleContext bundleContext, String destinationType,
-		String destinationName, int workersCoreSize, int workersMaxSize) {
-
-		DestinationConfiguration destinationConfiguration =
-			new DestinationConfiguration(destinationType, destinationName);
-
-		destinationConfiguration.setWorkersCoreSize(workersCoreSize);
-		destinationConfiguration.setWorkersMaxSize(workersMaxSize);
-
-		Destination destination = _destinationFactory.createDestination(
-			destinationConfiguration);
-
-		Dictionary<String, Object> dictionary =
-			HashMapDictionaryBuilder.<String, Object>put(
-				"destination.name", destination.getName()
-			).build();
-
-		ServiceRegistration<Destination> serviceRegistration =
-			bundleContext.registerService(
-				Destination.class, destination, dictionary);
-
-		_serviceRegistrations.add(serviceRegistration);
-
-		return destination;
 	}
 
 	private List<BackgroundTask> _translate(
@@ -746,12 +692,14 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 	@Reference
+	private BackgroundTaskMessagingConfigurator
+		_backgroundTaskMessagingConfigurator;
+
+	@Reference
 	private BackgroundTaskStatusRegistry _backgroundTaskStatusRegistry;
 
 	@Reference
 	private BackgroundTaskThreadLocalManager _backgroundTaskThreadLocalManager;
-
-	private volatile BundleContext _bundleContext;
 
 	@Reference
 	private ClusterMasterExecutor _clusterMasterExecutor;
@@ -764,8 +712,5 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 	@Reference
 	private MessageBus _messageBus;
-
-	private final Set<ServiceRegistration<Destination>> _serviceRegistrations =
-		new HashSet<>();
 
 }

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
@@ -17,22 +17,12 @@ package com.liferay.portal.background.task.internal;
 import com.liferay.background.task.kernel.util.comparator.BackgroundTaskCompletionDateComparator;
 import com.liferay.background.task.kernel.util.comparator.BackgroundTaskCreateDateComparator;
 import com.liferay.background.task.kernel.util.comparator.BackgroundTaskNameComparator;
-import com.liferay.portal.background.task.internal.messaging.BackgroundTaskMessageListener;
-import com.liferay.portal.background.task.internal.messaging.BackgroundTaskQueuingMessageListener;
-import com.liferay.portal.background.task.internal.messaging.RemoveOnCompletionBackgroundTaskStatusMessageListener;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutorRegistry;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistry;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocalManager;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lock.LockManager;
-import com.liferay.portal.kernel.messaging.Destination;
-import com.liferay.portal.kernel.messaging.DestinationFactory;
-import com.liferay.portal.kernel.messaging.DestinationNames;
-import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -599,34 +589,6 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		Destination backgroundTaskDestination = _messageBus.getDestination(
-			DestinationNames.BACKGROUND_TASK);
-
-		BackgroundTaskMessageListener backgroundTaskMessageListener =
-			new BackgroundTaskMessageListener(
-				_backgroundTaskExecutorRegistry, this,
-				_backgroundTaskStatusRegistry,
-				_backgroundTaskThreadLocalManager, _lockManager, _messageBus);
-
-		backgroundTaskDestination.register(backgroundTaskMessageListener);
-
-		Destination backgroundTaskStatusDestination =
-			_messageBus.getDestination(DestinationNames.BACKGROUND_TASK_STATUS);
-
-		BackgroundTaskQueuingMessageListener
-			backgroundTaskQueuingMessageListener =
-				new BackgroundTaskQueuingMessageListener(this, _lockManager);
-
-		backgroundTaskStatusDestination.register(
-			backgroundTaskQueuingMessageListener);
-
-		RemoveOnCompletionBackgroundTaskStatusMessageListener
-			removeOnCompletionBackgroundTaskStatusMessageListener =
-				new RemoveOnCompletionBackgroundTaskStatusMessageListener(this);
-
-		backgroundTaskStatusDestination.register(
-			removeOnCompletionBackgroundTaskStatusMessageListener);
-
 		if (!_clusterMasterExecutor.isEnabled() ||
 			_clusterMasterExecutor.isMaster()) {
 
@@ -686,9 +648,6 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 	}
 
 	@Reference
-	private BackgroundTaskExecutorRegistry _backgroundTaskExecutorRegistry;
-
-	@Reference
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 	@Reference
@@ -696,21 +655,6 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 		_backgroundTaskMessagingConfigurator;
 
 	@Reference
-	private BackgroundTaskStatusRegistry _backgroundTaskStatusRegistry;
-
-	@Reference
-	private BackgroundTaskThreadLocalManager _backgroundTaskThreadLocalManager;
-
-	@Reference
 	private ClusterMasterExecutor _clusterMasterExecutor;
-
-	@Reference
-	private DestinationFactory _destinationFactory;
-
-	@Reference
-	private LockManager _lockManager;
-
-	@Reference
-	private MessageBus _messageBus;
 
 }

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskMessagingConfigurator.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskMessagingConfigurator.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import java.util.Dictionary;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Vendel Toreki
+ */
+@Component(
+	immediate = true, service = BackgroundTaskMessagingConfigurator.class
+)
+public class BackgroundTaskMessagingConfigurator {
+
+	@Activate
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		_bundleContext = bundleContext;
+
+		_registerDestination(
+			bundleContext, DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
+			DestinationNames.BACKGROUND_TASK, 5, 10);
+
+		_registerDestination(
+			bundleContext, DestinationConfiguration.DESTINATION_TYPE_SERIAL,
+			DestinationNames.BACKGROUND_TASK_STATUS, 1, 1);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		for (ServiceRegistration<Destination> serviceRegistration :
+				_serviceRegistrations) {
+
+			Destination destination = _bundleContext.getService(
+				serviceRegistration.getReference());
+
+			serviceRegistration.unregister();
+
+			destination.destroy();
+		}
+
+		_bundleContext = null;
+	}
+
+	private Destination _registerDestination(
+		BundleContext bundleContext, String destinationType,
+		String destinationName, int workersCoreSize, int workersMaxSize) {
+
+		DestinationConfiguration destinationConfiguration =
+			new DestinationConfiguration(destinationType, destinationName);
+
+		destinationConfiguration.setWorkersCoreSize(workersCoreSize);
+		destinationConfiguration.setWorkersMaxSize(workersMaxSize);
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
+
+		Dictionary<String, Object> dictionary =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"destination.name", destination.getName()
+			).build();
+
+		ServiceRegistration<Destination> serviceRegistration =
+			bundleContext.registerService(
+				Destination.class, destination, dictionary);
+
+		_serviceRegistrations.add(serviceRegistration);
+
+		return destination;
+	}
+
+	private volatile BundleContext _bundleContext;
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private final Set<ServiceRegistration<Destination>> _serviceRegistrations =
+		new HashSet<>();
+
+}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -60,7 +60,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = "destination.name=" + DestinationNames.BACKGROUND_TASK,
-	service = {BackgroundTaskMessageListener.class, MessageListener.class}
+	service = MessageListener.class
 )
 public class BackgroundTaskMessageListener extends BaseMessageListener {
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.ServletContextClassLoaderPool;
 import com.liferay.portal.kernel.util.AggregateClassLoader;
@@ -50,25 +51,18 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Michael C. Han
  */
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.BACKGROUND_TASK,
+	service = {BackgroundTaskMessageListener.class, MessageListener.class}
+)
 public class BackgroundTaskMessageListener extends BaseMessageListener {
-
-	public BackgroundTaskMessageListener(
-		BackgroundTaskExecutorRegistry backgroundTaskExecutorRegistry,
-		BackgroundTaskManager backgroundTaskManager,
-		BackgroundTaskStatusRegistry backgroundTaskStatusRegistry,
-		BackgroundTaskThreadLocalManager backgroundTaskThreadLocalManager,
-		LockManager lockManager, MessageBus messageBus) {
-
-		_backgroundTaskExecutorRegistry = backgroundTaskExecutorRegistry;
-		_backgroundTaskManager = backgroundTaskManager;
-		_backgroundTaskStatusRegistry = backgroundTaskStatusRegistry;
-		_backgroundTaskThreadLocalManager = backgroundTaskThreadLocalManager;
-		_lockManager = lockManager;
-		_messageBus = messageBus;
-	}
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
@@ -332,13 +326,22 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 	private static final Log _log = LogFactoryUtil.getLog(
 		BackgroundTaskMessageListener.class);
 
-	private final BackgroundTaskExecutorRegistry
-		_backgroundTaskExecutorRegistry;
-	private final BackgroundTaskManager _backgroundTaskManager;
-	private final BackgroundTaskStatusRegistry _backgroundTaskStatusRegistry;
-	private final BackgroundTaskThreadLocalManager
-		_backgroundTaskThreadLocalManager;
-	private final LockManager _lockManager;
-	private final MessageBus _messageBus;
+	@Reference
+	private BackgroundTaskExecutorRegistry _backgroundTaskExecutorRegistry;
+
+	@Reference
+	private BackgroundTaskManager _backgroundTaskManager;
+
+	@Reference
+	private BackgroundTaskStatusRegistry _backgroundTaskStatusRegistry;
+
+	@Reference
+	private BackgroundTaskThreadLocalManager _backgroundTaskThreadLocalManager;
+
+	@Reference
+	private LockManager _lockManager;
+
+	@Reference
+	private MessageBus _messageBus;
 
 }

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -36,9 +36,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = "destination.name=" + DestinationNames.BACKGROUND_TASK_STATUS,
-	service = {
-		BackgroundTaskQueuingMessageListener.class, MessageListener.class
-	}
+	service = MessageListener.class
 )
 public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -22,21 +22,25 @@ import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.Validator;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Michael C. Han
  */
-public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
-
-	public BackgroundTaskQueuingMessageListener(
-		BackgroundTaskManager backgroundTaskManager, LockManager lockManager) {
-
-		_backgroundTaskManager = backgroundTaskManager;
-
-		_backgroundTaskLockHelper = new BackgroundTaskLockHelper(lockManager);
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.BACKGROUND_TASK_STATUS,
+	service = {
+		BackgroundTaskQueuingMessageListener.class, MessageListener.class
 	}
+)
+public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
@@ -76,6 +80,11 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 		}
 	}
 
+	@Reference(unbind = "-")
+	protected void setLockManager(LockManager lockManager) {
+		_backgroundTaskLockHelper = new BackgroundTaskLockHelper(lockManager);
+	}
+
 	private void _executeQueuedBackgroundTasks(String taskExecutorClassName) {
 		if (_log.isDebugEnabled()) {
 			_log.debug(
@@ -104,7 +113,9 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 	private static final Log _log = LogFactoryUtil.getLog(
 		BackgroundTaskQueuingMessageListener.class);
 
-	private final BackgroundTaskLockHelper _backgroundTaskLockHelper;
-	private final BackgroundTaskManager _backgroundTaskManager;
+	private BackgroundTaskLockHelper _backgroundTaskLockHelper;
+
+	@Reference
+	private BackgroundTaskManager _backgroundTaskManager;
 
 }

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/RemoveOnCompletionBackgroundTaskStatusMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/RemoveOnCompletionBackgroundTaskStatusMessageListener.java
@@ -39,10 +39,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = "destination.name=" + DestinationNames.BACKGROUND_TASK_STATUS,
-	service = {
-		MessageListener.class,
-		RemoveOnCompletionBackgroundTaskStatusMessageListener.class
-	}
+	service = MessageListener.class
 )
 public class RemoveOnCompletionBackgroundTaskStatusMessageListener
 	extends BaseMessageListener {

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/RemoveOnCompletionBackgroundTaskStatusMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/RemoveOnCompletionBackgroundTaskStatusMessageListener.java
@@ -21,24 +21,31 @@ import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstant
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.Serializable;
 
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Michael C. Han
  */
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.BACKGROUND_TASK_STATUS,
+	service = {
+		MessageListener.class,
+		RemoveOnCompletionBackgroundTaskStatusMessageListener.class
+	}
+)
 public class RemoveOnCompletionBackgroundTaskStatusMessageListener
 	extends BaseMessageListener {
-
-	public RemoveOnCompletionBackgroundTaskStatusMessageListener(
-		BackgroundTaskManager backgroundTaskManager) {
-
-		_backgroundTaskManager = backgroundTaskManager;
-	}
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
@@ -82,6 +89,7 @@ public class RemoveOnCompletionBackgroundTaskStatusMessageListener
 	private static final Log _log = LogFactoryUtil.getLog(
 		RemoveOnCompletionBackgroundTaskStatusMessageListener.class);
 
-	private final BackgroundTaskManager _backgroundTaskManager;
+	@Reference
+	private BackgroundTaskManager _backgroundTaskManager;
 
 }


### PR DESCRIPTION
Hi @yuhai ,

Based on @tinatian 's [comment](https://github.com/liferay-core-infra/liferay-portal/pull/411#issuecomment-1059548160) , I made some modifications on the original pull request. Changed the `MessageListener` classes to to be initialized by adding
```
property = "destination.name=" + DestinationNames.BACKGROUND_TASK,
```
to the `Component` annotations. According to my tests, it seems to be working: all `doReceive()` methods of the listeners are called properly.

Can you please help me validate whether my solution is correct?

Thanks,
Vendel