### PR TITLE
LPS 154229 05 27

### DIFF
--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -74,7 +74,7 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 		RollingFileAppender rollingFileAppender =
 			_rollingFileAppenders.computeIfAbsent(
 				CompanyThreadLocal.getCompanyId(),
-				key -> _createRollingFileAppender(key));
+				this::_createRollingFileAppender);
 
 		rollingFileAppender.append(logEvent);
 	}

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -76,6 +76,10 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 				CompanyThreadLocal.getCompanyId(),
 				this::_createRollingFileAppender);
 
+		if (rollingFileAppender == null) {
+			return;
+		}
+
 		rollingFileAppender.append(logEvent);
 	}
 
@@ -241,7 +245,9 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 		RollingFileAppender rollingFileAppender = builder.build();
 
-		rollingFileAppender.start();
+		if (rollingFileAppender != null) {
+			rollingFileAppender.start();
+		}
 
 		return rollingFileAppender;
 	}

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.Deflater;
@@ -41,8 +42,10 @@ import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.DirectFileRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.DirectWriteRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.PatternProcessor;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.action.Action;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
@@ -257,8 +260,47 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 		builder.withFilePermissions(_filePermissions);
 		builder.withImmediateFlush(_immediateFlush);
 		builder.withLocking(_locking);
-		builder.withStrategy(_rolloverStrategy);
 		builder.withPolicy(_triggeringPolicy);
+
+		if (_rolloverStrategy instanceof DirectWriteRolloverStrategy) {
+			DirectWriteRolloverStrategy directWriteRolloverStrategy =
+				(DirectWriteRolloverStrategy)_rolloverStrategy;
+
+			DirectWriteRolloverStrategy.Builder
+				directWriteRolloverStrategyBuilder =
+					DirectWriteRolloverStrategy.newBuilder();
+
+			directWriteRolloverStrategyBuilder.withMaxFiles(
+				String.valueOf(directWriteRolloverStrategy.getMaxFiles()));
+			directWriteRolloverStrategyBuilder.withCompressionLevelStr(
+				String.valueOf(
+					directWriteRolloverStrategy.getCompressionLevel()));
+			directWriteRolloverStrategyBuilder.withStopCustomActionsOnError(
+				directWriteRolloverStrategy.isStopCustomActionsOnError());
+
+			List<Action> customActions =
+				directWriteRolloverStrategy.getCustomActions();
+
+			directWriteRolloverStrategyBuilder.withCustomActions(
+				customActions.toArray(new Action[0]));
+
+			PatternProcessor patternProcessor =
+				directWriteRolloverStrategy.getTempCompressedFilePattern();
+
+			if (patternProcessor != null) {
+				directWriteRolloverStrategyBuilder.
+					withTempCompressedFilePattern(
+						patternProcessor.getPattern());
+			}
+
+			directWriteRolloverStrategyBuilder.withConfig(
+				loggerContext.getConfiguration());
+
+			builder.withStrategy(directWriteRolloverStrategyBuilder.build());
+		}
+		else {
+			builder.withStrategy(_rolloverStrategy);
+		}
 
 		RollingFileAppender rollingFileAppender = builder.build();
 

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -16,8 +16,6 @@ package com.liferay.petra.log4j.internal;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -29,7 +27,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.zip.Deflater;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -40,8 +37,6 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
-import org.apache.logging.log4j.core.appender.rolling.DirectFileRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.DirectWriteRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.PatternProcessor;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
@@ -91,69 +86,6 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 		@Override
 		public CompanyLogRoutingAppender build() {
-			if (getName() == null) {
-				if (_log.isErrorEnabled()) {
-					_log.error("No name provided");
-				}
-
-				return null;
-			}
-
-			if (!_bufferedIo && (_bufferSize > 0)) {
-				if (_log.isErrorEnabled()) {
-					_log.error(
-						"The bufferSize is set to " + _bufferSize +
-							" but bufferedIO is not true");
-				}
-			}
-
-			if (_filePattern == null) {
-				if (_log.isErrorEnabled()) {
-					_log.error("No file name pattern provided");
-				}
-
-				return null;
-			}
-
-			if (_policy == null) {
-				if (_log.isErrorEnabled()) {
-					_log.error("No TriggeringPolicy provided");
-				}
-
-				return null;
-			}
-
-			if (_strategy == null) {
-				if (_fileName != null) {
-					_strategy = DefaultRolloverStrategy.newBuilder(
-					).withCompressionLevelStr(
-						String.valueOf(Deflater.DEFAULT_COMPRESSION)
-					).withConfig(
-						getConfiguration()
-					).build();
-				}
-				else {
-					_strategy = DirectWriteRolloverStrategy.newBuilder(
-					).withCompressionLevelStr(
-						String.valueOf(Deflater.DEFAULT_COMPRESSION)
-					).withConfig(
-						getConfiguration()
-					).build();
-				}
-			}
-			else if ((_fileName == null) &&
-					 !(_strategy instanceof DirectFileRolloverStrategy)) {
-
-				if (_log.isErrorEnabled()) {
-					_log.error(
-						"When no file name is provided a " +
-							DirectFileRolloverStrategy.class.getSimpleName() +
-								" must be configured");
-				}
-
-				return null;
-			}
-
 			return new CompanyLogRoutingAppender(
 				_advertise, _advertiseUri, _append, _bufferedIo, _bufferSize,
 				_createOnDemand, _fileGroup, _fileName, _fileOwner,
@@ -316,9 +248,6 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 	private static final boolean _ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.COMPANY_LOG_ENABLED));
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		CompanyLogRoutingAppender.class);
 
 	private final boolean _advertise;
 	private final String _advertiseUri;

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -71,6 +72,10 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 	@Override
 	public void append(LogEvent logEvent) {
+		if (!_ENABLED) {
+			return;
+		}
+
 		RollingFileAppender rollingFileAppender =
 			_rollingFileAppenders.computeIfAbsent(
 				CompanyThreadLocal.getCompanyId(),
@@ -308,6 +313,9 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 		return rollingFileAppender;
 	}
+
+	private static final boolean _ENABLED = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.COMPANY_LOG_ENABLED));
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CompanyLogRoutingAppender.class);

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -14,19 +14,30 @@
 
 package com.liferay.petra.log4j.internal;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.Deflater;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.DirectFileRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.DirectWriteRolloverStrategy;
@@ -57,6 +68,12 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 	@Override
 	public void append(LogEvent logEvent) {
+		RollingFileAppender rollingFileAppender =
+			_rollingFileAppenders.computeIfAbsent(
+				CompanyThreadLocal.getCompanyId(),
+				key -> _createRollingFileAppender(key));
+
+		rollingFileAppender.append(logEvent);
 	}
 
 	public static class Builder
@@ -212,6 +229,44 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 		_rolloverStrategy = rolloverStrategy;
 	}
 
+	private RollingFileAppender _createRollingFileAppender(long companyId) {
+		RollingFileAppender.Builder builder = RollingFileAppender.newBuilder();
+
+		LoggerContext loggerContext = (LoggerContext)LogManager.getContext();
+
+		builder.setConfiguration(loggerContext.getConfiguration());
+
+		builder.setName(companyId + StringPool.DASH + getName());
+		builder.setIgnoreExceptions(ignoreExceptions());
+		builder.setLayout(getLayout());
+		builder.withAdvertise(_advertise);
+		builder.withAdvertiseUri(_advertiseUri);
+		builder.withAppend(_append);
+		builder.withBufferedIo(_bufferedIo);
+		builder.withBufferSize(_bufferSize);
+		builder.withCreateOnDemand(_createOnDemand);
+		builder.withFileGroup(_fileGroup);
+		builder.withFileName(_fileName);
+		builder.withFileOwner(_fileOwner);
+		builder.withFilePattern(
+			StringBundler.concat(
+				StringUtil.replace(
+					PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\', '/'),
+				"/logs/companies/", companyId, StringPool.SLASH,
+				StringUtil.extractLast(_filePattern, StringPool.SLASH)));
+		builder.withFilePermissions(_filePermissions);
+		builder.withImmediateFlush(_immediateFlush);
+		builder.withLocking(_locking);
+		builder.withStrategy(_rolloverStrategy);
+		builder.withPolicy(_triggeringPolicy);
+
+		RollingFileAppender rollingFileAppender = builder.build();
+
+		rollingFileAppender.start();
+
+		return rollingFileAppender;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		CompanyLogRoutingAppender.class);
 
@@ -228,6 +283,8 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 	private final String _filePermissions;
 	private final boolean _immediateFlush;
 	private final boolean _locking;
+	private final Map<Long, RollingFileAppender> _rollingFileAppenders =
+		new ConcurrentHashMap<>();
 	private final RolloverStrategy _rolloverStrategy;
 	private final TriggeringPolicy _triggeringPolicy;
 

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -14,7 +14,12 @@
 
 package com.liferay.petra.log4j.internal;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
 import java.io.Serializable;
+
+import java.util.zip.Deflater;
 
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
@@ -22,6 +27,9 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.DirectFileRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.DirectWriteRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
@@ -58,6 +66,69 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 		@Override
 		public CompanyLogRoutingAppender build() {
+			if (getName() == null) {
+				if (_log.isErrorEnabled()) {
+					_log.error("No name provided");
+				}
+
+				return null;
+			}
+
+			if (!_bufferedIo && (_bufferSize > 0)) {
+				if (_log.isErrorEnabled()) {
+					_log.error(
+						"The bufferSize is set to " + _bufferSize +
+							" but bufferedIO is not true");
+				}
+			}
+
+			if (_filePattern == null) {
+				if (_log.isErrorEnabled()) {
+					_log.error("No file name pattern provided");
+				}
+
+				return null;
+			}
+
+			if (_policy == null) {
+				if (_log.isErrorEnabled()) {
+					_log.error("No TriggeringPolicy provided");
+				}
+
+				return null;
+			}
+
+			if (_strategy == null) {
+				if (_fileName != null) {
+					_strategy = DefaultRolloverStrategy.newBuilder(
+					).withCompressionLevelStr(
+						String.valueOf(Deflater.DEFAULT_COMPRESSION)
+					).withConfig(
+						getConfiguration()
+					).build();
+				}
+				else {
+					_strategy = DirectWriteRolloverStrategy.newBuilder(
+					).withCompressionLevelStr(
+						String.valueOf(Deflater.DEFAULT_COMPRESSION)
+					).withConfig(
+						getConfiguration()
+					).build();
+				}
+			}
+			else if ((_fileName == null) &&
+					 !(_strategy instanceof DirectFileRolloverStrategy)) {
+
+				if (_log.isErrorEnabled()) {
+					_log.error(
+						"When no file name is provided a " +
+							DirectFileRolloverStrategy.class.getSimpleName() +
+								" must be configured");
+				}
+
+				return null;
+			}
+
 			return new CompanyLogRoutingAppender(
 				_advertise, _advertiseUri, _append, _bufferedIo, _bufferSize,
 				_createOnDemand, _fileGroup, _fileName, _fileOwner,
@@ -140,6 +211,9 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 		_triggeringPolicy = triggeringPolicy;
 		_rolloverStrategy = rolloverStrategy;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CompanyLogRoutingAppender.class);
 
 	private final boolean _advertise;
 	private final String _advertiseUri;

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -67,7 +67,7 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 
 	@PluginBuilderFactory
 	public static Builder newBuilder() {
-		return (Builder)new Builder().asBuilder();
+		return new Builder();
 	}
 
 	@Override

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.petra.log4j.internal;
+
+import java.io.Serializable;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.util.Constants;
+
+/**
+ * @author Hai Yu
+ */
+@Plugin(
+	category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE,
+	name = CompanyLogRoutingAppender.PLUGIN_NAME, printObject = true
+)
+public final class CompanyLogRoutingAppender extends AbstractAppender {
+
+	public static final String PLUGIN_NAME = "CompanyLogRouting";
+
+	@PluginBuilderFactory
+	public static Builder newBuilder() {
+		return (Builder)new Builder().asBuilder();
+	}
+
+	@Override
+	public void append(LogEvent logEvent) {
+	}
+
+	public static class Builder
+		extends AbstractAppender.Builder<Builder>
+		implements org.apache.logging.log4j.core.util.Builder
+			<CompanyLogRoutingAppender> {
+
+		@Override
+		public CompanyLogRoutingAppender build() {
+			return new CompanyLogRoutingAppender(
+				_advertise, _advertiseUri, _append, _bufferedIo, _bufferSize,
+				_createOnDemand, _fileGroup, _fileName, _fileOwner,
+				_filePattern, _filePermissions, _immediateFlush, _locking,
+				_policy, _strategy, getName(), getLayout(), getFilter());
+		}
+
+		@PluginBuilderAttribute("advertise")
+		private boolean _advertise;
+
+		@PluginBuilderAttribute("advertiseUri")
+		private String _advertiseUri;
+
+		@PluginBuilderAttribute("append")
+		private boolean _append = true;
+
+		@PluginBuilderAttribute("bufferedIo")
+		private boolean _bufferedIo = true;
+
+		@PluginBuilderAttribute("bufferSize")
+		private int _bufferSize = Constants.ENCODER_BYTE_BUFFER_SIZE;
+
+		@PluginBuilderAttribute("createOnDemand")
+		private boolean _createOnDemand;
+
+		@PluginBuilderAttribute("fileGroup")
+		private String _fileGroup;
+
+		@PluginBuilderAttribute("fileName")
+		private String _fileName;
+
+		@PluginBuilderAttribute("fileOwner")
+		private String _fileOwner;
+
+		@PluginBuilderAttribute("filePattern")
+		@Required
+		private String _filePattern;
+
+		@PluginBuilderAttribute("filePermissions")
+		private String _filePermissions;
+
+		@PluginBuilderAttribute("immediateFlush")
+		private boolean _immediateFlush = true;
+
+		@PluginBuilderAttribute("locking")
+		private boolean _locking;
+
+		@PluginElement("Policy")
+		@Required
+		private TriggeringPolicy _policy;
+
+		@PluginElement("Strategy")
+		private RolloverStrategy _strategy;
+
+	}
+
+	private CompanyLogRoutingAppender(
+		boolean advertise, String advertiseUri, boolean append,
+		boolean bufferedIo, int bufferSize, boolean createOnDemand,
+		String fileGroup, String fileName, String fileOwner, String filePattern,
+		String filePermissions, boolean immediateFlush, boolean locking,
+		TriggeringPolicy triggeringPolicy, RolloverStrategy rolloverStrategy,
+		String name, Layout<? extends Serializable> layout, Filter filter) {
+
+		super(name, filter, layout, true, null);
+
+		_advertise = advertise;
+		_advertiseUri = advertiseUri;
+		_append = append;
+		_bufferedIo = bufferedIo;
+		_bufferSize = bufferSize;
+		_createOnDemand = createOnDemand;
+		_fileGroup = fileGroup;
+		_fileName = fileName;
+		_fileOwner = fileOwner;
+		_filePattern = filePattern;
+		_filePermissions = filePermissions;
+		_immediateFlush = immediateFlush;
+		_locking = locking;
+		_triggeringPolicy = triggeringPolicy;
+		_rolloverStrategy = rolloverStrategy;
+	}
+
+	private final boolean _advertise;
+	private final String _advertiseUri;
+	private final boolean _append;
+	private final boolean _bufferedIo;
+	private final int _bufferSize;
+	private final boolean _createOnDemand;
+	private final String _fileGroup;
+	private final String _fileName;
+	private final String _fileOwner;
+	private final String _filePattern;
+	private final String _filePermissions;
+	private final boolean _immediateFlush;
+	private final boolean _locking;
+	private final RolloverStrategy _rolloverStrategy;
+	private final TriggeringPolicy _triggeringPolicy;
+
+}

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -21,6 +21,14 @@
 
 			<DirectWriteRolloverStrategy />
 		</Appender>
+
+		<Appender filePattern="@liferay.home@/logs/liferay.%d{yyyy-MM-dd}.log" ignoreExceptions="false" name="COMPANY_LOG_ROUTING_TEXT_FILE" type="CompanyLogRouting">
+			<Layout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%t][%c{1}:%L] %m%n" type="PatternLayout" />
+
+			<TimeBasedTriggeringPolicy />
+
+			<DirectWriteRolloverStrategy />
+		</Appender>
 	</Appenders>
 
 	<Loggers>
@@ -285,6 +293,7 @@
 			<AppenderRef ref="CONSOLE" />
 			<AppenderRef ref="TEXT_FILE" />
 			<AppenderRef ref="XML_FILE" />
+			<AppenderRef ref="COMPANY_LOG_ROUTING_TEXT_FILE" />
 		</Root>
 	</Loggers>
 </Configuration>

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1868,6 +1868,15 @@
     #company.encryption.key.size=512
 
     #
+    # Set this to true to enable each company log output to itself log files. It
+    # will use default TEXT_FILE and XML_FILE RollingFileAppender of
+    # portal-log4j.xml as output format.
+    #
+    # Env: LIFERAY_COMPANY_PERIOD_LOG_PERIOD_ENABLED
+    #
+    company.log.enabled=true
+
+    #
     # The login field is prepopulated with the company's domain name if the
     # login is unpopulated and user authentication is based on email addresses.
     # Set this to false to disable the behavior.

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 53.0.2
+Bundle-Version: 53.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -448,6 +448,8 @@ public interface PropsKeys {
 	public static final String COMPANY_ENCRYPTION_KEY_SIZE =
 		"company.encryption.key.size";
 
+	public static final String COMPANY_LOG_ENABLED = "company.log.enabled";
+
 	public static final String COMPANY_LOGIN_PREPOPULATE_DOMAIN =
 		"company.login.prepopulate.domain";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 36.3.0
+version 36.4.0


### PR DESCRIPTION
- LPS-154229 Create a custom appender. It copies the attributes of RollingFileAppender.Builder(bufferSize, immediateFlush and bufferSize are from AbstractOutputStreamAppender.Builder because RollingFileAppender.Builder extends AbstractOutputStreamAppender.Builder), and saves these attributes for later use.
- LPS-154229 Copy if condition from RollingFileAppender.Build.build().
- LPS-154229 Make CompanyLogRoutingAppender as distribution point to output company's log to specific log file.
- LPS-154229 Need to build one new DirectWriteRolloverStrategy when RolloverStrategy is DirectWriteRolloverStrategy. DirectWriteRolloverStrategy included the current fileName, this will cause appenders use the same log file.
- LPS-154229 Add one property to enable/disable the appender's log output function.
- LPS-154229 Semantic Versioning
- LPS-154229 SF
- LPS-154229 Remove copied logic, just let RollingFileAppender.Builder handle it
- LPS-154229 SF
- LPS-154229 Add null protection
