### PR TITLE
LPS 154230 7 13

### DIFF
--- a/modules/apps/petra/petra-log4j/bnd.bnd
+++ b/modules/apps/petra/petra-log4j/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Petra Log4j
 Bundle-SymbolicName: com.liferay.petra.log4j
-Bundle-Version: 5.0.13
+Bundle-Version: 5.1.0
 Export-Package: com.liferay.petra.log4j

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/Log4JUtil.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/Log4JUtil.java
@@ -98,6 +98,10 @@ public class Log4JUtil {
 		}
 	}
 
+	public static String getCompanyLogDirectory(long companyId) {
+		return Log4jConfigUtil.getCompanyLogDirectory(companyId);
+	}
+
 	public static Map<String, String> getCustomLogSettings() {
 		return new HashMap<>(_customLogSettings);
 	}

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CentralizedConfiguration.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CentralizedConfiguration.java
@@ -67,11 +67,14 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 	}
 
 	public String getCompanyLogDirectory(long companyId) {
-		if (_companyLogRoutingAppender == null) {
+		CompanyLogRoutingAppender companyLogRoutingAppender =
+			_companyLogRoutingAppender;
+
+		if (companyLogRoutingAppender == null) {
 			return null;
 		}
 
-		return _companyLogRoutingAppender.getCompanyLogDirectory(companyId);
+		return companyLogRoutingAppender.getCompanyLogDirectory(companyId);
 	}
 
 	@Override
@@ -93,6 +96,8 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 		Map<String, Appender> newAppenders =
 			abstractConfiguration.getAppenders();
 
+		CompanyLogRoutingAppender companyLogRoutingAppender = null;
+
 		for (Appender newAppender : newAppenders.values()) {
 			newAppender.start();
 
@@ -101,7 +106,7 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 			if ((newAppender instanceof CompanyLogRoutingAppender) &&
 				appenderName.equals("COMPANY_LOG_ROUTING_TEXT_FILE")) {
 
-				_companyLogRoutingAppender =
+				companyLogRoutingAppender =
 					(CompanyLogRoutingAppender)newAppender;
 			}
 
@@ -137,6 +142,10 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 			}
 
 			currentAppender.stop();
+		}
+
+		if (companyLogRoutingAppender != null) {
+			_companyLogRoutingAppender = companyLogRoutingAppender;
 		}
 	}
 
@@ -270,6 +279,6 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 		}
 	}
 
-	private CompanyLogRoutingAppender _companyLogRoutingAppender;
+	private volatile CompanyLogRoutingAppender _companyLogRoutingAppender;
 
 }

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CentralizedConfiguration.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CentralizedConfiguration.java
@@ -66,6 +66,10 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 		loggerContext.updateLoggers();
 	}
 
+	public CompanyLogRoutingAppender getCompanyLogRoutingAppender() {
+		return _companyLogRoutingAppender;
+	}
+
 	@Override
 	public void start() {
 		LoggerConfig rootLoggerConfig = getRootLogger();
@@ -89,6 +93,13 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 			newAppender.start();
 
 			String appenderName = newAppender.getName();
+
+			if ((newAppender instanceof CompanyLogRoutingAppender) &&
+				appenderName.equals("COMPANY_LOG_ROUTING_TEXT_FILE")) {
+
+				_companyLogRoutingAppender =
+					(CompanyLogRoutingAppender)newAppender;
+			}
 
 			Appender currentAppender = currentAppenders.put(
 				appenderName, newAppender);
@@ -254,5 +265,7 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 			throw new ExceptionInInitializerError(exception);
 		}
 	}
+
+	private CompanyLogRoutingAppender _companyLogRoutingAppender;
 
 }

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CentralizedConfiguration.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CentralizedConfiguration.java
@@ -66,8 +66,12 @@ public class CentralizedConfiguration extends AbstractConfiguration {
 		loggerContext.updateLoggers();
 	}
 
-	public CompanyLogRoutingAppender getCompanyLogRoutingAppender() {
-		return _companyLogRoutingAppender;
+	public String getCompanyLogDirectory(long companyId) {
+		if (_companyLogRoutingAppender == null) {
+			return null;
+		}
+
+		return _companyLogRoutingAppender.getCompanyLogDirectory(companyId);
 	}
 
 	@Override

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -81,10 +81,6 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 	public String getCompanyLogDirectory(long companyId) {
 		Appender appender = _appenders.get(companyId);
 
-		if (appender == null) {
-			return null;
-		}
-
 		if (appender instanceof RollingFileAppender) {
 			RollingFileAppender rollingFileAppender =
 				(RollingFileAppender)appender;

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -92,9 +92,7 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 			String filePattern = rollingFileAppender.getFilePattern();
 
 			return filePattern.substring(
-				0,
-				StringUtil.lastIndexOfAny(
-					filePattern, new char[] {CharPool.SLASH}));
+				0, filePattern.lastIndexOf(CharPool.SLASH));
 		}
 
 		return null;

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/CompanyLogRoutingAppender.java
@@ -14,6 +14,7 @@
 
 package com.liferay.petra.log4j.internal;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -75,6 +76,28 @@ public final class CompanyLogRoutingAppender extends AbstractAppender {
 			CompanyThreadLocal.getCompanyId(), this::_createAppender);
 
 		appender.append(logEvent);
+	}
+
+	public String getCompanyLogDirectory(long companyId) {
+		Appender appender = _appenders.get(companyId);
+
+		if (appender == null) {
+			return null;
+		}
+
+		if (appender instanceof RollingFileAppender) {
+			RollingFileAppender rollingFileAppender =
+				(RollingFileAppender)appender;
+
+			String filePattern = rollingFileAppender.getFilePattern();
+
+			return filePattern.substring(
+				0,
+				StringUtil.lastIndexOfAny(
+					filePattern, new char[] {CharPool.SLASH}));
+		}
+
+		return null;
 	}
 
 	public static class Builder

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/Log4jConfigUtil.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/Log4jConfigUtil.java
@@ -145,6 +145,17 @@ public class Log4jConfigUtil {
 		return Collections.emptyMap();
 	}
 
+	public static String getCompanyLogDirectory(long companyId) {
+		CompanyLogRoutingAppender companyLogRoutingAppender =
+			_centralizedConfiguration.getCompanyLogRoutingAppender();
+
+		if (companyLogRoutingAppender == null) {
+			return null;
+		}
+
+		return companyLogRoutingAppender.getCompanyLogDirectory(companyId);
+	}
+
 	public static java.util.logging.Level getJDKLevel(String levelString) {
 		if (StringUtil.equalsIgnoreCase(levelString, Level.DEBUG.toString())) {
 			return java.util.logging.Level.FINE;

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/Log4jConfigUtil.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/internal/Log4jConfigUtil.java
@@ -146,14 +146,7 @@ public class Log4jConfigUtil {
 	}
 
 	public static String getCompanyLogDirectory(long companyId) {
-		CompanyLogRoutingAppender companyLogRoutingAppender =
-			_centralizedConfiguration.getCompanyLogRoutingAppender();
-
-		if (companyLogRoutingAppender == null) {
-			return null;
-		}
-
-		return companyLogRoutingAppender.getCompanyLogDirectory(companyId);
+		return _centralizedConfiguration.getCompanyLogDirectory(companyId);
 	}
 
 	public static java.util.logging.Level getJDKLevel(String levelString) {

--- a/modules/apps/petra/petra-log4j/src/main/resources/com/liferay/petra/log4j/packageinfo
+++ b/modules/apps/petra/petra-log4j/src/main/resources/com/liferay/petra/log4j/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/internal/Log4jConfigUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/internal/Log4jConfigUtilTest.java
@@ -14,12 +14,17 @@
 
 package com.liferay.petra.log4j.internal;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.rule.NewEnv;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
@@ -259,6 +264,68 @@ public class Log4jConfigUtilTest {
 	}
 
 	@Test
+	public void testGetCompanyLogDirectory() throws Exception {
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (!GetterUtil.getBoolean(
+				PropsUtil.get(PropsKeys.COMPANY_LOG_ENABLED))) {
+
+			Assert.assertNull(
+				Log4jConfigUtil.getCompanyLogDirectory(companyId));
+
+			return;
+		}
+
+		String loggerName = StringUtil.randomString();
+
+		Log4jConfigUtil.configureLog4J(
+			_generateXMLConfigurationContent(loggerName, _INFO));
+
+		Assert.assertNull(Log4jConfigUtil.getCompanyLogDirectory(companyId));
+
+		File tempLogFileDir = null;
+
+		try {
+			Path path = Files.createTempDirectory(
+				Log4jConfigUtilTest.class.getName());
+
+			tempLogFileDir = path.toFile();
+
+			String tempLogFileDirPath = StringUtil.replace(
+				tempLogFileDir.getPath(), CharPool.BACK_SLASH,
+				CharPool.FORWARD_SLASH);
+
+			String filePattern = "liferay-@company.id@.%d{yyyy-MM-dd}.xml.log";
+
+			Log4jConfigUtil.configureLog4J(
+				_generateCompanyLogRoutingAppenderConfigurationContent(
+					"COMPANY_LOG_ROUTING_TEXT_FILE",
+					StringBundler.concat(
+						tempLogFileDirPath, CharPool.FORWARD_SLASH,
+						filePattern),
+					loggerName, _INFO));
+
+			Logger logger = (Logger)LogManager.getLogger(loggerName);
+
+			logger.info("Test message");
+
+			Assert.assertEquals(
+				"Company log directory should be " + tempLogFileDirPath,
+				tempLogFileDirPath,
+				Log4jConfigUtil.getCompanyLogDirectory(companyId));
+		}
+		finally {
+			if (tempLogFileDir != null) {
+				for (File file : tempLogFileDir.listFiles()) {
+					file.delete();
+				}
+
+				tempLogFileDir.delete();
+			}
+		}
+	}
+
+	@Test
 	public void testGetJDKLevel() {
 		Assert.assertEquals(
 			"FINE", String.valueOf(Log4jConfigUtil.getJDKLevel(_DEBUG)));
@@ -400,6 +467,30 @@ public class Log4jConfigUtilTest {
 		else {
 			Assert.assertEquals("Logging priority is wrong", priority, _OFF);
 		}
+	}
+
+	private String _generateCompanyLogRoutingAppenderConfigurationContent(
+		String appenderName, String filePattern, String loggerName,
+		String priority) {
+
+		StringBundler sb = new StringBundler(14);
+
+		sb.append("<?xml version=\"1.0\"?><Configuration strict=\"true\">");
+		sb.append("<Appenders><Appender name=\"");
+		sb.append(appenderName);
+		sb.append("\" filePattern=\"");
+		sb.append(filePattern);
+		sb.append("\" type=\"CompanyLogRouting\">");
+		sb.append("<TimeBasedTriggeringPolicy /><DirectWriteRolloverStrategy ");
+		sb.append("/></Appender></Appenders><Loggers><Logger level= \"");
+		sb.append(priority);
+		sb.append("\" name=\"");
+		sb.append(loggerName);
+		sb.append("\"><AppenderRef ref=\"");
+		sb.append(appenderName);
+		sb.append("\" /></Logger></Loggers></Configuration>");
+
+		return sb.toString();
 	}
 
 	private String _generateLog4j1XMLConfigurationContent(

--- a/modules/apps/portal/portal-company-log-test/bnd.bnd
+++ b/modules/apps/portal/portal-company-log-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Company Log Test
+Bundle-SymbolicName: com.liferay.portal.company.log.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal/portal-company-log-test/build.gradle
+++ b/modules/apps/portal/portal-company-log-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	testIntegrationCompile project(":apps:petra:petra-log4j")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal/portal-company-log-test/src/testIntegration/java/com/liferay/portal/company/log/servlet/test/CompanyLogServletTest.java
+++ b/modules/apps/portal/portal-company-log-test/src/testIntegration/java/com/liferay/portal/company/log/servlet/test/CompanyLogServletTest.java
@@ -1,0 +1,573 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.company.log.servlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.log4j.Log4JUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchCompanyException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MimeTypes;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.webdav.methods.Method;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import java.nio.file.Files;
+
+import java.util.List;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Hai Yu
+ */
+@RunWith(Arquillian.class)
+public class CompanyLogServletTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_newCompany = CompanyTestUtil.addCompany();
+
+		_adminUser = UserTestUtil.addCompanyAdminUser(_newCompany);
+
+		File logFilesDir = new File(
+			Log4JUtil.getCompanyLogDirectory(_newCompany.getCompanyId()));
+
+		for (File file : logFilesDir.listFiles()) {
+			_logFile = file;
+
+			break;
+		}
+
+		_defaultCompany = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		File logFilesDir = _logFile.getParentFile();
+
+		_logFile.delete();
+
+		logFilesDir.delete();
+
+		_companyLocalService.deleteCompany(_newCompany);
+	}
+
+	@Test
+	public void testDownloadLogFileWithFileNotFound() throws Exception {
+		String fileName = StringUtil.randomString() + ".log";
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest(
+				StringBundler.concat(
+					StringPool.SLASH, _newCompany.getCompanyId(),
+					StringPool.SLASH, fileName),
+				_adminUser);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_NOT_FOUND,
+				_mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				FileNotFoundException.class, throwable.getClass());
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Unable to find log file ", fileName, " for company ",
+					_newCompany.getCompanyId()),
+				throwable.getMessage());
+		}
+	}
+
+	@Test
+	public void testDownloadLogFileWithNoSuchCompany() throws Exception {
+		long companyId = 1;
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest(
+				StringBundler.concat(
+					StringPool.SLASH, companyId, StringPool.SLASH,
+					_logFile.getName()),
+				_adminUser);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_NOT_FOUND,
+				_mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				NoSuchCompanyException.class, throwable.getClass());
+			Assert.assertEquals(
+				"No Company exists with the primary key " + companyId,
+				throwable.getMessage());
+		}
+	}
+
+	@Test
+	public void testDownloadLogFileWithoutStartIndexAndEndIndex()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest(
+				StringBundler.concat(
+					StringPool.SLASH, _newCompany.getCompanyId(),
+					StringPool.SLASH, _logFile.getName()),
+				_adminUser);
+
+		_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
+
+		_assertHttpServletResponse(0, (int)_logFile.length());
+	}
+
+	@Test
+	public void testDownloadLogFileWithStartIndexGreaterThanOrEqualsToEndIndex()
+		throws Exception {
+
+		_assertDownloadLogFileWithInvalidData("0", "0");
+		_assertDownloadLogFileWithInvalidData("10", "10");
+		_assertDownloadLogFileWithInvalidData("2", "1");
+		_assertDownloadLogFileWithInvalidData("10", "0");
+	}
+
+	@Test
+	public void testDownloadLogFileWithStartIndexLessThanEndIndex()
+		throws Exception {
+
+		_assertDownloadLogFileWithValidData("2", "5");
+		_assertDownloadLogFileWithValidData("0", "10");
+		_assertDownloadLogFileWithValidData(
+			"1", String.valueOf(Integer.MAX_VALUE));
+		_assertDownloadLogFileWithValidData(
+			"2", String.valueOf(_logFile.length() + 1));
+	}
+
+	@Test
+	public void testDownloadLogFileWithStartIndexOrEndIndexForNull()
+		throws Exception {
+
+		_assertDownloadLogFileWithValidData("", "");
+		_assertDownloadLogFileWithValidData(null, null);
+		_assertDownloadLogFileWithValidData("3", "");
+		_assertDownloadLogFileWithInvalidData("", "0");
+		_assertDownloadLogFileWithInvalidData(
+			String.valueOf(_logFile.length()), "");
+	}
+
+	@Test
+	public void testDownloadLogFileWithStartIndexOrEndIndexLessThanZero()
+		throws Exception {
+
+		_assertDownloadLogFileWithInvalidData("-3", "3");
+		_assertDownloadLogFileWithInvalidData("-3", "-2");
+		_assertDownloadLogFileWithInvalidData("3", "-3");
+	}
+
+	@Test
+	public void testDownloadLogFileWithUnauthorizedAccess() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest(
+				StringBundler.concat(
+					StringPool.SLASH, _newCompany.getCompanyId(), "/../"),
+				_adminUser);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_FORBIDDEN,
+				_mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(PrincipalException.class, throwable.getClass());
+			Assert.assertEquals("Unauthorized access", throwable.getMessage());
+		}
+	}
+
+	@Test
+	public void testListCompaniesLogFilesWithCompanyAdminUser()
+		throws Exception {
+
+		_servlet.service(
+			_createMockHttpServletRequest("/", _adminUser),
+			_mockHttpServletResponse);
+
+		String responseContent = _mockHttpServletResponse.getContentAsString();
+
+		Assert.assertFalse(
+			"Response content should not include webId " +
+				_defaultCompany.getWebId(),
+			responseContent.contains(_defaultCompany.getWebId()));
+		Assert.assertTrue(
+			"Response content should include webId " + _newCompany.getWebId(),
+			responseContent.contains(_newCompany.getWebId()));
+
+		_assertCompanyLogFilesDisplay(_newCompany, responseContent);
+	}
+
+	@Test
+	public void testListCompaniesLogFilesWithCompanyUser() throws Exception {
+		User user = UserTestUtil.addUser(_newCompany);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(
+				_createMockHttpServletRequest("/", user),
+				_mockHttpServletResponse);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_FORBIDDEN,
+				_mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				PrincipalException.MustBeCompanyAdmin.class,
+				throwable.getClass());
+		}
+	}
+
+	@Test
+	public void testListCompaniesLogFilesWithOmniAdminUser() throws Exception {
+		User omniAdminUser = null;
+
+		try {
+			omniAdminUser = UserTestUtil.addOmniAdminUser();
+
+			_servlet.service(
+				_createMockHttpServletRequest("/", omniAdminUser),
+				_mockHttpServletResponse);
+
+			String responseContent =
+				_mockHttpServletResponse.getContentAsString();
+
+			Assert.assertTrue(
+				"Response content should include webId " +
+					_defaultCompany.getWebId(),
+				responseContent.contains(_defaultCompany.getWebId()));
+			Assert.assertTrue(
+				"Response content should include webId " +
+					_newCompany.getWebId(),
+				responseContent.contains(_newCompany.getWebId()));
+
+			_assertCompanyLogFilesDisplay(_defaultCompany, responseContent);
+			_assertCompanyLogFilesDisplay(_newCompany, responseContent);
+		}
+		finally {
+			if (omniAdminUser != null) {
+				_userLocalService.deleteUser(omniAdminUser);
+			}
+		}
+	}
+
+	@Test
+	public void testUserUnauthenticated() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(
+				_createMockHttpServletRequest("/", (User)null),
+				_mockHttpServletResponse);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_FORBIDDEN,
+				_mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(PrincipalException.class, throwable.getClass());
+			Assert.assertEquals(
+				"The current user is not authenticated",
+				throwable.getMessage());
+		}
+	}
+
+	private void _assertCompanyLogFilesDisplay(
+			Company company, String responseContent)
+		throws Exception {
+
+		String logFilesDirPath = Log4JUtil.getCompanyLogDirectory(
+			company.getCompanyId());
+
+		File logFilesDir = new File(logFilesDirPath);
+
+		File[] files = logFilesDir.listFiles();
+
+		Assert.assertTrue(
+			"The directory " + logFilesDirPath + " must have log files",
+			files.length > 0);
+
+		for (File file : logFilesDir.listFiles()) {
+			Assert.assertTrue(
+				"Response content should include fileName " + file.getName(),
+				responseContent.contains(file.getName()));
+		}
+	}
+
+	private void _assertDownloadLogFileWithInvalidData(
+			String startIndex, String endIndex)
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(
+				_createMockHttpServletRequest(startIndex, endIndex),
+				_mockHttpServletResponse);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_FORBIDDEN,
+				_mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(PrincipalException.class, throwable.getClass());
+			Assert.assertEquals(
+				"startIndex or endIndex can not be less than 0, and " +
+					"startIndex can not be greater than or equal to endIndex",
+				throwable.getMessage());
+		}
+		finally {
+			_mockHttpServletResponse.setCommitted(false);
+			_mockHttpServletResponse.reset();
+		}
+	}
+
+	private void _assertDownloadLogFileWithValidData(
+			String startIndex, String endIndex)
+		throws Exception {
+
+		try {
+			_servlet.service(
+				_createMockHttpServletRequest(startIndex, endIndex),
+				_mockHttpServletResponse);
+
+			if (Validator.isNull(startIndex)) {
+				startIndex = "0";
+			}
+
+			int start = GetterUtil.getIntegerStrict(startIndex);
+
+			int logFileLength = (int)_logFile.length();
+
+			if (Validator.isNull(endIndex) && (start >= 0)) {
+				endIndex = String.valueOf(logFileLength);
+			}
+
+			int end = GetterUtil.getIntegerStrict(endIndex);
+
+			if (end > logFileLength) {
+				end = logFileLength;
+			}
+
+			if (start != 0) {
+				--start;
+			}
+
+			_assertHttpServletResponse(start, end);
+		}
+		finally {
+			_mockHttpServletResponse.setCommitted(false);
+			_mockHttpServletResponse.reset();
+		}
+	}
+
+	private void _assertHttpServletResponse(int start, int end)
+		throws Exception {
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		sb.append("; filename=\"");
+		sb.append(_logFile.getName());
+		sb.append("\"");
+
+		Assert.assertEquals(
+			sb.toString(),
+			_mockHttpServletResponse.getHeader(
+				HttpHeaders.CONTENT_DISPOSITION));
+
+		Assert.assertEquals(
+			String.valueOf(end - start),
+			_mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_LENGTH));
+
+		Assert.assertEquals(
+			_mimeTypes.getContentType(_logFile),
+			_mockHttpServletResponse.getContentType());
+
+		String logFileContent = new String(
+			Files.readAllBytes(_logFile.toPath()));
+
+		logFileContent = logFileContent.substring(start, end);
+
+		Assert.assertEquals(
+			logFileContent, _mockHttpServletResponse.getContentAsString());
+	}
+
+	private MockHttpServletRequest _createMockHttpServletRequest(
+		String startIndex, String endIndex) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest(
+				StringBundler.concat(
+					StringPool.SLASH, _newCompany.getCompanyId(),
+					StringPool.SLASH, _logFile.getName()),
+				_adminUser);
+
+		mockHttpServletRequest.setParameter(
+			"startIndex", String.valueOf(startIndex));
+		mockHttpServletRequest.setParameter(
+			"endIndex", String.valueOf(endIndex));
+
+		return mockHttpServletRequest;
+	}
+
+	private MockHttpServletRequest _createMockHttpServletRequest(
+		String path, User user) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(Method.GET, "/company-log" + path);
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, user);
+		mockHttpServletRequest.setContextPath("/company-log");
+		mockHttpServletRequest.setPathInfo(path);
+
+		return mockHttpServletRequest;
+	}
+
+	private static User _adminUser;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	private static Company _defaultCompany;
+	private static File _logFile;
+	private static Company _newCompany;
+
+	@Inject
+	private MimeTypes _mimeTypes;
+
+	private final MockHttpServletResponse _mockHttpServletResponse =
+		new MockHttpServletResponse();
+
+	@Inject(
+		filter = "osgi.http.whiteboard.servlet.name=com.liferay.portal.company.log.internal.servlet.CompanyLogServlet"
+	)
+	private Servlet _servlet;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal/portal-company-log-test/src/testIntegration/java/com/liferay/portal/company/log/servlet/test/CompanyLogServletTest.java
+++ b/modules/apps/portal/portal-company-log-test/src/testIntegration/java/com/liferay/portal/company/log/servlet/test/CompanyLogServletTest.java
@@ -106,78 +106,32 @@ public class CompanyLogServletTest {
 	public void testDownloadLogFileWithFileNotFound() throws Exception {
 		String fileName = StringUtil.randomString() + ".log";
 
-		MockHttpServletRequest mockHttpServletRequest =
+		_assertHttpServletResponseStatusAndLogInfo(
 			_createMockHttpServletRequest(
 				StringBundler.concat(
 					StringPool.SLASH, _newCompany.getCompanyId(),
 					StringPool.SLASH, fileName),
-				_adminUser);
-
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.company.log.internal.servlet." +
-					"CompanyLogServlet",
-				LoggerTestUtil.WARN)) {
-
-			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
-
-			Assert.assertEquals(
-				HttpServletResponse.SC_NOT_FOUND,
-				_mockHttpServletResponse.getStatus());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Throwable throwable = logEntry.getThrowable();
-
-			Assert.assertEquals(
-				FileNotFoundException.class, throwable.getClass());
-			Assert.assertEquals(
-				StringBundler.concat(
-					"Unable to find log file ", fileName, " for company ",
-					_newCompany.getCompanyId()),
-				throwable.getMessage());
-		}
+				_adminUser),
+			FileNotFoundException.class,
+			StringBundler.concat(
+				"Unable to find log file ", fileName, " for company ",
+				_newCompany.getCompanyId()),
+			HttpServletResponse.SC_NOT_FOUND);
 	}
 
 	@Test
 	public void testDownloadLogFileWithNoSuchCompany() throws Exception {
 		long companyId = 1;
 
-		MockHttpServletRequest mockHttpServletRequest =
+		_assertHttpServletResponseStatusAndLogInfo(
 			_createMockHttpServletRequest(
 				StringBundler.concat(
 					StringPool.SLASH, companyId, StringPool.SLASH,
 					_logFile.getName()),
-				_adminUser);
-
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.company.log.internal.servlet." +
-					"CompanyLogServlet",
-				LoggerTestUtil.WARN)) {
-
-			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
-
-			Assert.assertEquals(
-				HttpServletResponse.SC_NOT_FOUND,
-				_mockHttpServletResponse.getStatus());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Throwable throwable = logEntry.getThrowable();
-
-			Assert.assertEquals(
-				NoSuchCompanyException.class, throwable.getClass());
-			Assert.assertEquals(
-				"No Company exists with the primary key " + companyId,
-				throwable.getMessage());
-		}
+				_adminUser),
+			NoSuchCompanyException.class,
+			"No Company exists with the primary key " + companyId,
+			HttpServletResponse.SC_NOT_FOUND);
 	}
 
 	@Test
@@ -241,34 +195,13 @@ public class CompanyLogServletTest {
 
 	@Test
 	public void testDownloadLogFileWithUnauthorizedAccess() throws Exception {
-		MockHttpServletRequest mockHttpServletRequest =
+		_assertHttpServletResponseStatusAndLogInfo(
 			_createMockHttpServletRequest(
 				StringBundler.concat(
 					StringPool.SLASH, _newCompany.getCompanyId(), "/../"),
-				_adminUser);
-
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.company.log.internal.servlet." +
-					"CompanyLogServlet",
-				LoggerTestUtil.WARN)) {
-
-			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
-
-			Assert.assertEquals(
-				HttpServletResponse.SC_FORBIDDEN,
-				_mockHttpServletResponse.getStatus());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Throwable throwable = logEntry.getThrowable();
-
-			Assert.assertEquals(PrincipalException.class, throwable.getClass());
-			Assert.assertEquals("Unauthorized access", throwable.getMessage());
-		}
+				_adminUser),
+			PrincipalException.class, "Unauthorized access",
+			HttpServletResponse.SC_FORBIDDEN);
 	}
 
 	@Test
@@ -296,31 +229,13 @@ public class CompanyLogServletTest {
 	public void testListCompaniesLogFilesWithCompanyUser() throws Exception {
 		User user = UserTestUtil.addUser(_newCompany);
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.company.log.internal.servlet." +
-					"CompanyLogServlet",
-				LoggerTestUtil.WARN)) {
-
-			_servlet.service(
-				_createMockHttpServletRequest("/", user),
-				_mockHttpServletResponse);
-
-			Assert.assertEquals(
-				HttpServletResponse.SC_FORBIDDEN,
-				_mockHttpServletResponse.getStatus());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Throwable throwable = logEntry.getThrowable();
-
-			Assert.assertEquals(
-				PrincipalException.MustBeCompanyAdmin.class,
-				throwable.getClass());
-		}
+		_assertHttpServletResponseStatusAndLogInfo(
+			_createMockHttpServletRequest("/", user),
+			PrincipalException.MustBeCompanyAdmin.class,
+			StringBundler.concat(
+				"User ", user.getUserId(), " must be the company ",
+				"administrator to perform the action"),
+			HttpServletResponse.SC_FORBIDDEN);
 	}
 
 	@Test
@@ -358,32 +273,10 @@ public class CompanyLogServletTest {
 
 	@Test
 	public void testUserUnauthenticated() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.company.log.internal.servlet." +
-					"CompanyLogServlet",
-				LoggerTestUtil.WARN)) {
-
-			_servlet.service(
-				_createMockHttpServletRequest("/", (User)null),
-				_mockHttpServletResponse);
-
-			Assert.assertEquals(
-				HttpServletResponse.SC_FORBIDDEN,
-				_mockHttpServletResponse.getStatus());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Throwable throwable = logEntry.getThrowable();
-
-			Assert.assertEquals(PrincipalException.class, throwable.getClass());
-			Assert.assertEquals(
-				"The current user is not authenticated",
-				throwable.getMessage());
-		}
+		_assertHttpServletResponseStatusAndLogInfo(
+			_createMockHttpServletRequest("/", (User)null),
+			PrincipalException.class, "The current user is not authenticated",
+			HttpServletResponse.SC_FORBIDDEN);
 	}
 
 	private void _assertCompanyLogFilesDisplay(
@@ -412,32 +305,13 @@ public class CompanyLogServletTest {
 			String startIndex, String endIndex)
 		throws Exception {
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.company.log.internal.servlet." +
-					"CompanyLogServlet",
-				LoggerTestUtil.WARN)) {
-
-			_servlet.service(
+		try {
+			_assertHttpServletResponseStatusAndLogInfo(
 				_createMockHttpServletRequest(startIndex, endIndex),
-				_mockHttpServletResponse);
-
-			Assert.assertEquals(
-				HttpServletResponse.SC_FORBIDDEN,
-				_mockHttpServletResponse.getStatus());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Throwable throwable = logEntry.getThrowable();
-
-			Assert.assertEquals(PrincipalException.class, throwable.getClass());
-			Assert.assertEquals(
+				PrincipalException.class,
 				"startIndex or endIndex can not be less than 0, and " +
 					"startIndex can not be greater than or equal to endIndex",
-				throwable.getMessage());
+				HttpServletResponse.SC_FORBIDDEN);
 		}
 		finally {
 			_mockHttpServletResponse.setCommitted(false);
@@ -514,6 +388,33 @@ public class CompanyLogServletTest {
 
 		Assert.assertEquals(
 			logFileContent, _mockHttpServletResponse.getContentAsString());
+	}
+
+	private void _assertHttpServletResponseStatusAndLogInfo(
+			MockHttpServletRequest mockHttpServletRequest, Class<?> clazz,
+			String message, int status)
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.company.log.internal.servlet." +
+					"CompanyLogServlet",
+				LoggerTestUtil.WARN)) {
+
+			_servlet.service(mockHttpServletRequest, _mockHttpServletResponse);
+
+			Assert.assertEquals(status, _mockHttpServletResponse.getStatus());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(clazz, throwable.getClass());
+			Assert.assertEquals(message, throwable.getMessage());
+		}
 	}
 
 	private MockHttpServletRequest _createMockHttpServletRequest(

--- a/modules/apps/portal/portal-company-log/bnd.bnd
+++ b/modules/apps/portal/portal-company-log/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Company Log
+Bundle-SymbolicName: com.liferay.portal.company.log
+Bundle-Version: 1.0.0

--- a/modules/apps/portal/portal-company-log/build.gradle
+++ b/modules/apps/portal/portal-company-log/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:petra:petra-log4j")
 	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/portal/portal-company-log/build.gradle
+++ b/modules/apps/portal/portal-company-log/build.gradle
@@ -2,7 +2,9 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal/portal-company-log/build.gradle
+++ b/modules/apps/portal/portal-company-log/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/portal/portal-company-log/build.gradle
+++ b/modules/apps/portal/portal-company-log/build.gradle
@@ -7,5 +7,6 @@ dependencies {
 	compileOnly project(":apps:petra:petra-log4j")
 	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/portal/profile/ModulePortalProfile.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/portal/profile/ModulePortalProfile.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.company.log.internal.portal.profile;
+
+import com.liferay.portal.company.log.internal.servlet.CompanyLogServlet;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.profile.BaseDSModulePortalProfile;
+import com.liferay.portal.profile.PortalProfile;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Hai Yu
+ */
+@Component(immediate = true, service = PortalProfile.class)
+public class ModulePortalProfile extends BaseDSModulePortalProfile {
+
+	@Activate
+	protected void activate(ComponentContext componentContext) {
+		List<String> supportedPortalProfileNames = null;
+
+		if (GetterUtil.getBoolean(_props.get(PropsKeys.COMPANY_LOG_ENABLED))) {
+			supportedPortalProfileNames = new ArrayList<>();
+
+			supportedPortalProfileNames.add(
+				PortalProfile.PORTAL_PROFILE_NAME_CE);
+			supportedPortalProfileNames.add(
+				PortalProfile.PORTAL_PROFILE_NAME_DXP);
+		}
+		else {
+			supportedPortalProfileNames = Collections.emptyList();
+		}
+
+		init(
+			componentContext, supportedPortalProfileNames,
+			CompanyLogServlet.class.getName());
+	}
+
+	@Reference
+	private Props _props;
+
+}

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -71,7 +71,13 @@ public class CompanyLogServlet extends HttpServlet {
 		throws IOException, ServletException {
 
 		try {
-			_checkPermission(httpServletRequest);
+			PermissionChecker permissionChecker = _getPermissionChecker(
+				httpServletRequest);
+
+			if (!permissionChecker.isCompanyAdmin()) {
+				throw new PrincipalException.MustBeCompanyAdmin(
+					permissionChecker.getUserId());
+			}
 
 			String path = HttpComponentsUtil.fixPath(
 				httpServletRequest.getPathInfo());
@@ -79,11 +85,13 @@ public class CompanyLogServlet extends HttpServlet {
 			String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 
 			if (pathArray.length == 0) {
-				_listCompaniesLogFiles(httpServletRequest, httpServletResponse);
+				_listCompaniesLogFiles(
+					permissionChecker, httpServletRequest, httpServletResponse);
 			}
 			else if (pathArray.length == 2) {
 				_downloadLogFile(
-					httpServletRequest, httpServletResponse, pathArray);
+					permissionChecker, httpServletRequest, httpServletResponse,
+					pathArray);
 			}
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
@@ -105,26 +113,8 @@ public class CompanyLogServlet extends HttpServlet {
 		}
 	}
 
-	private void _checkPermission(HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		User user = _portal.getUser(httpServletRequest);
-
-		if (user == null) {
-			throw new PrincipalException(
-				"The current user is not company admin");
-		}
-
-		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
-			user);
-
-		if (!permissionChecker.isCompanyAdmin()) {
-			throw new PrincipalException.MustBeCompanyAdmin(
-				permissionChecker.getUserId());
-		}
-	}
-
 	private void _downloadLogFile(
+			PermissionChecker permissionChecker,
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, String[] pathArray)
 		throws Exception {
@@ -136,10 +126,9 @@ public class CompanyLogServlet extends HttpServlet {
 				"No Company exists with the primary key " + companyId);
 		}
 
-		if (!_isViewCompanyAllowed(httpServletRequest, companyId)) {
-			throw new PrincipalException(
-				"The current user is not current company " + companyId +
-					" admin");
+		if (!permissionChecker.isCompanyAdmin(companyId)) {
+			throw new PrincipalException.MustBeCompanyAdmin(
+				permissionChecker.getUserId());
 		}
 
 		String fileName = pathArray[1];
@@ -174,17 +163,22 @@ public class CompanyLogServlet extends HttpServlet {
 		}
 	}
 
-	private boolean _isViewCompanyAllowed(
-			HttpServletRequest httpServletRequest, long companyId)
+	private PermissionChecker _getPermissionChecker(
+			HttpServletRequest httpServletRequest)
 		throws Exception {
 
-		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
-			_portal.getUser(httpServletRequest));
+		User user = _portal.getUser(httpServletRequest);
 
-		return permissionChecker.isCompanyAdmin(companyId);
+		if (user == null) {
+			throw new PrincipalException(
+				"The current user is not authenticated");
+		}
+
+		return _permissionCheckerFactory.create(user);
 	}
 
 	private void _listCompaniesLogFiles(
+			PermissionChecker permissionChecker,
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
@@ -197,9 +191,7 @@ public class CompanyLogServlet extends HttpServlet {
 
 		_companyLocalService.forEachCompany(
 			company -> {
-				if (_isViewCompanyAllowed(
-						httpServletRequest, company.getCompanyId())) {
-
+				if (permissionChecker.isCompanyAdmin(company.getCompanyId())) {
 					File logFilesDir = new File(
 						StringBundler.concat(
 							StringUtil.replace(

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -54,7 +54,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Hai Yu
  */
 @Component(
-	immediate = true,
+	enabled = false, immediate = true,
 	property = {
 		"osgi.http.whiteboard.servlet.name=com.liferay.portal.company.log.internal.servlet.CompanyLogServlet",
 		"osgi.http.whiteboard.servlet.pattern=/company-log/*",

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -76,11 +76,6 @@ public class CompanyLogServlet extends HttpServlet {
 			PermissionChecker permissionChecker = _getPermissionChecker(
 				httpServletRequest);
 
-			if (!permissionChecker.isCompanyAdmin()) {
-				throw new PrincipalException.MustBeCompanyAdmin(
-					permissionChecker.getUserId());
-			}
-
 			String path = HttpComponentsUtil.fixPath(
 				httpServletRequest.getPathInfo());
 
@@ -196,12 +191,16 @@ public class CompanyLogServlet extends HttpServlet {
 				company -> _listCompanyLogFiles(
 					httpServletRequest, printWriter, company));
 		}
-		else {
+		else if (permissionChecker.isCompanyAdmin()) {
 			User user = permissionChecker.getUser();
 
 			_listCompanyLogFiles(
 				httpServletRequest, printWriter,
 				_companyLocalService.getCompany(user.getCompanyId()));
+		}
+		else {
+			throw new PrincipalException.MustBeCompanyAdmin(
+				permissionChecker.getUserId());
 		}
 
 		printWriter.println("</body></html>");

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -251,7 +251,15 @@ public class CompanyLogServlet extends HttpServlet {
 			sb.append(
 				_language.formatStorageSize(
 					file.length(), httpServletRequest.getLocale()));
-			sb.append(")</a></li>");
+			sb.append(")</a><form action = \"");
+			sb.append(href);
+			sb.append("\" method = \"GET\">");
+			sb.append("StartIndex: <input name = \"startIndex\" type = \"text");
+			sb.append("\" />");
+			sb.append("EndIndex: <input name = \"endIndex\" type = \"text\" ");
+			sb.append("/> <input type = \"submit\" value = \"download\" />");
+			sb.append("</form>");
+			sb.append("</li>");
 		}
 
 		sb.append("</ul>");

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchCompanyException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -246,7 +247,11 @@ public class CompanyLogServlet extends HttpServlet {
 			sb.append(href);
 			sb.append("\">");
 			sb.append(file.getName());
-			sb.append("</a></li>");
+			sb.append(" (");
+			sb.append(
+				_language.formatStorageSize(
+					file.length(), httpServletRequest.getLocale()));
+			sb.append(")</a></li>");
 		}
 
 		sb.append("</ul>");
@@ -257,6 +262,9 @@ public class CompanyLogServlet extends HttpServlet {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private MimeTypes _mimeTypes;

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -148,19 +148,18 @@ public class CompanyLogServlet extends HttpServlet {
 
 		File logFile = path.toFile();
 
-		if (logFile.exists()) {
-			ServletResponseUtil.sendFile(
-				httpServletRequest, httpServletResponse, fileName,
-				new FileInputStream(logFile), logFile.length(),
-				_mimeTypes.getContentType(fileName),
-				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
-		}
-		else {
+		if (!logFile.exists()) {
 			throw new FileNotFoundException(
 				StringBundler.concat(
 					"Unable to find log file ", fileName, " for company ",
 					companyId));
 		}
+
+		ServletResponseUtil.sendFile(
+			httpServletRequest, httpServletResponse, fileName,
+			new FileInputStream(logFile), logFile.length(),
+			_mimeTypes.getContentType(fileName),
+			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 	}
 
 	private PermissionChecker _getPermissionChecker(

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.company.log.internal.servlet;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -40,6 +39,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
@@ -91,13 +91,13 @@ public class CompanyLogServlet extends HttpServlet {
 					pathArray);
 			}
 		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
+		catch (FileNotFoundException fileNotFoundException) {
 			if (_log.isWarnEnabled()) {
-				_log.warn(noSuchFileEntryException);
+				_log.warn(fileNotFoundException);
 			}
 
 			_portal.sendError(
-				HttpServletResponse.SC_NOT_FOUND, noSuchFileEntryException,
+				HttpServletResponse.SC_NOT_FOUND, fileNotFoundException,
 				httpServletRequest, httpServletResponse);
 		}
 		catch (Exception exception) {
@@ -156,7 +156,7 @@ public class CompanyLogServlet extends HttpServlet {
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
-			throw new NoSuchFileEntryException();
+			throw new FileNotFoundException();
 		}
 	}
 

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -155,7 +155,10 @@ public class CompanyLogServlet extends HttpServlet {
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
-			throw new FileNotFoundException();
+			throw new FileNotFoundException(
+				StringBundler.concat(
+					"Unable to find log file ", fileName, " for company ",
+					companyId));
 		}
 	}
 

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -21,6 +21,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchCompanyException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -189,43 +190,54 @@ public class CompanyLogServlet extends HttpServlet {
 
 		printWriter.println("<html><body>");
 
-		_companyLocalService.forEachCompany(
-			company -> {
-				if (permissionChecker.isCompanyAdmin(company.getCompanyId())) {
-					File logFilesDir = new File(
-						StringBundler.concat(
-							StringUtil.replace(
-								PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\',
-								'/'),
-							"/logs/companies/", company.getCompanyId()));
+		if (permissionChecker.isOmniadmin()) {
+			_companyLocalService.forEachCompany(
+				company -> _listCompanyLogFiles(
+					httpServletRequest, printWriter, company));
+		}
+		else {
+			User user = permissionChecker.getUser();
 
-					if (!logFilesDir.isDirectory()) {
-						return;
-					}
-
-					printWriter.println("<h1>" + company.getWebId() + "</h1>");
-					printWriter.println("<ul>");
-
-					for (File file : logFilesDir.listFiles()) {
-						String herf = StringBundler.concat(
-							_portal.getPortalURL(httpServletRequest),
-							_portal.getPathContext(), "/o/company-log/",
-							company.getCompanyId(), StringPool.SLASH,
-							file.getName());
-
-						printWriter.println(
-							"<li><a target=\"_self\" href=\"" + herf + "\">");
-
-						printWriter.println(file.getName());
-						printWriter.println("</a>");
-						printWriter.println("</li>");
-					}
-
-					printWriter.println("</ul>");
-				}
-			});
+			_listCompanyLogFiles(
+				httpServletRequest, printWriter,
+				_companyLocalService.getCompany(user.getCompanyId()));
+		}
 
 		printWriter.println("</body></html>");
+	}
+
+	private void _listCompanyLogFiles(
+		HttpServletRequest httpServletRequest, PrintWriter printWriter,
+		Company company) {
+
+		File logFilesDir = new File(
+			StringBundler.concat(
+				StringUtil.replace(
+					PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\', '/'),
+				"/logs/companies/", company.getCompanyId()));
+
+		if (!logFilesDir.isDirectory()) {
+			return;
+		}
+
+		printWriter.println("<h1>" + company.getWebId() + "</h1>");
+		printWriter.println("<ul>");
+
+		for (File file : logFilesDir.listFiles()) {
+			String herf = StringBundler.concat(
+				_portal.getPortalURL(httpServletRequest),
+				_portal.getPathContext(), "/o/company-log/",
+				company.getCompanyId(), StringPool.SLASH, file.getName());
+
+			printWriter.println(
+				"<li><a target=\"_self\" href=\"" + herf + "\">");
+
+			printWriter.println(file.getName());
+			printWriter.println("</a>");
+			printWriter.println("</li>");
+		}
+
+		printWriter.println("</ul>");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -41,6 +41,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -134,21 +137,15 @@ public class CompanyLogServlet extends HttpServlet {
 
 		String fileName = pathArray[1];
 
-		String path = StringBundler.concat(
-			logFilesDirPath, StringPool.SLASH, fileName);
+		Path path = Paths.get(logFilesDirPath, fileName);
 
-		File logFile = new File(path);
+		path = path.normalize();
 
-		String canonicalPath = logFile.getCanonicalPath();
-
-		if (File.separatorChar != CharPool.SLASH) {
-			canonicalPath = StringUtil.replace(
-				canonicalPath, File.separatorChar, CharPool.SLASH);
-		}
-
-		if (!path.equals(canonicalPath)) {
+		if (!path.startsWith(logFilesDirPath)) {
 			throw new PrincipalException("Unauthorized access");
 		}
+
+		File logFile = path.toFile();
 
 		if (logFile.exists()) {
 			ServletResponseUtil.sendFile(

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.company.log.internal.servlet;
+
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchCompanyException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.MimeTypes;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Hai Yu
+ */
+@Component(
+	immediate = true,
+	property = {
+		"osgi.http.whiteboard.servlet.name=com.liferay.portal.company.log.internal.servlet.CompanyLogServlet",
+		"osgi.http.whiteboard.servlet.pattern=/company-log/*",
+		"servlet.init.httpMethods=GET"
+	},
+	service = Servlet.class
+)
+public class CompanyLogServlet extends HttpServlet {
+
+	@Override
+	protected void doGet(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException, ServletException {
+
+		try {
+			_checkPermission(httpServletRequest);
+
+			String path = HttpComponentsUtil.fixPath(
+				httpServletRequest.getPathInfo());
+
+			String[] pathArray = StringUtil.split(path, CharPool.SLASH);
+
+			if (pathArray.length == 0) {
+				_listCompaniesLogFiles(httpServletRequest, httpServletResponse);
+			}
+			else if (pathArray.length == 2) {
+				_downloadLogFile(
+					httpServletRequest, httpServletResponse, pathArray);
+			}
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(noSuchFileEntryException);
+			}
+
+			_portal.sendError(
+				HttpServletResponse.SC_NOT_FOUND, noSuchFileEntryException,
+				httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			_portal.sendError(
+				exception, httpServletRequest, httpServletResponse);
+		}
+	}
+
+	private void _checkPermission(HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		User user = _portal.getUser(httpServletRequest);
+
+		if (user == null) {
+			throw new PrincipalException(
+				"The current user is not company admin");
+		}
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			user);
+
+		if (!permissionChecker.isCompanyAdmin()) {
+			throw new PrincipalException.MustBeCompanyAdmin(
+				permissionChecker.getUserId());
+		}
+	}
+
+	private void _downloadLogFile(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String[] pathArray)
+		throws Exception {
+
+		long companyId = Long.valueOf(pathArray[0]);
+
+		if (_companyLocalService.fetchCompanyById(companyId) == null) {
+			throw new NoSuchCompanyException(
+				"No Company exists with the primary key " + companyId);
+		}
+
+		if (!_isViewCompanyAllowed(httpServletRequest, companyId)) {
+			throw new PrincipalException(
+				"The current user is not current company " + companyId +
+					" admin");
+		}
+
+		String fileName = pathArray[1];
+
+		String path = StringBundler.concat(
+			StringUtil.replace(
+				PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\', '/'),
+			"/logs/companies/", companyId, StringPool.SLASH, fileName);
+
+		File logFile = new File(path);
+
+		String canonicalPath = logFile.getCanonicalPath();
+
+		if (File.separatorChar != CharPool.SLASH) {
+			canonicalPath = StringUtil.replace(
+				canonicalPath, File.separatorChar, CharPool.SLASH);
+		}
+
+		if (!path.equals(canonicalPath)) {
+			throw new PrincipalException("Unauthorized access");
+		}
+
+		if (logFile.exists()) {
+			ServletResponseUtil.sendFile(
+				httpServletRequest, httpServletResponse, fileName,
+				new FileInputStream(logFile), logFile.length(),
+				_mimeTypes.getContentType(fileName),
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		}
+		else {
+			throw new NoSuchFileEntryException();
+		}
+	}
+
+	private boolean _isViewCompanyAllowed(
+			HttpServletRequest httpServletRequest, long companyId)
+		throws Exception {
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			_portal.getUser(httpServletRequest));
+
+		return permissionChecker.isCompanyAdmin(companyId);
+	}
+
+	private void _listCompaniesLogFiles(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		httpServletResponse.setContentType("text/html");
+
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		printWriter.println("<html><body>");
+
+		_companyLocalService.forEachCompany(
+			company -> {
+				if (_isViewCompanyAllowed(
+						httpServletRequest, company.getCompanyId())) {
+
+					File logFilesDir = new File(
+						StringBundler.concat(
+							StringUtil.replace(
+								PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\',
+								'/'),
+							"/logs/companies/", company.getCompanyId()));
+
+					if (!logFilesDir.isDirectory()) {
+						return;
+					}
+
+					printWriter.println("<h1>" + company.getWebId() + "</h1>");
+					printWriter.println("<ul>");
+
+					for (File file : logFilesDir.listFiles()) {
+						String herf = StringBundler.concat(
+							_portal.getPortalURL(httpServletRequest),
+							_portal.getPathContext(), "/o/company-log/",
+							company.getCompanyId(), StringPool.SLASH,
+							file.getName());
+
+						printWriter.println(
+							"<li><a target=\"_self\" href=\"" + herf + "\">");
+
+						printWriter.println(file.getName());
+						printWriter.println("</a>");
+						printWriter.println("</li>");
+					}
+
+					printWriter.println("</ul>");
+				}
+			});
+
+		printWriter.println("</body></html>");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CompanyLogServlet.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private MimeTypes _mimeTypes;
+
+	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.MimeTypes;
 import com.liferay.portal.kernel.util.Portal;
@@ -120,7 +121,7 @@ public class CompanyLogServlet extends HttpServlet {
 			HttpServletResponse httpServletResponse, String[] pathArray)
 		throws Exception {
 
-		long companyId = Long.valueOf(pathArray[0]);
+		long companyId = GetterUtil.getLongStrict(pathArray[0]);
 
 		if (_companyLocalService.fetchCompanyById(companyId) == null) {
 			throw new NoSuchCompanyException(
@@ -224,13 +225,13 @@ public class CompanyLogServlet extends HttpServlet {
 		printWriter.println("<ul>");
 
 		for (File file : logFilesDir.listFiles()) {
-			String herf = StringBundler.concat(
+			String href = StringBundler.concat(
 				_portal.getPortalURL(httpServletRequest),
 				_portal.getPathContext(), "/o/company-log/",
 				company.getCompanyId(), StringPool.SLASH, file.getName());
 
 			printWriter.println(
-				"<li><a target=\"_self\" href=\"" + herf + "\">");
+				"<li><a target=\"_self\" href=\"" + href + "\">");
 
 			printWriter.println(file.getName());
 			printWriter.println("</a>");

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -254,8 +253,5 @@ public class CompanyLogServlet extends HttpServlet {
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.company.log.internal.servlet;
 
+import com.liferay.petra.log4j.Log4JUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -32,8 +33,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.MimeTypes;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.File;
@@ -127,12 +126,16 @@ public class CompanyLogServlet extends HttpServlet {
 				permissionChecker.getUserId());
 		}
 
+		String logFilesDirPath = Log4JUtil.getCompanyLogDirectory(companyId);
+
+		if (logFilesDirPath == null) {
+			return;
+		}
+
 		String fileName = pathArray[1];
 
 		String path = StringBundler.concat(
-			StringUtil.replace(
-				PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\', '/'),
-			"/logs/companies/", companyId, StringPool.SLASH, fileName);
+			logFilesDirPath, StringPool.SLASH, fileName);
 
 		File logFile = new File(path);
 
@@ -209,11 +212,14 @@ public class CompanyLogServlet extends HttpServlet {
 		HttpServletRequest httpServletRequest, PrintWriter printWriter,
 		Company company) {
 
-		File logFilesDir = new File(
-			StringBundler.concat(
-				StringUtil.replace(
-					PropsUtil.get(PropsKeys.LIFERAY_HOME), '\\', '/'),
-				"/logs/companies/", company.getCompanyId()));
+		String logFilesDirPath = Log4JUtil.getCompanyLogDirectory(
+			company.getCompanyId());
+
+		if (logFilesDirPath == null) {
+			return;
+		}
+
+		File logFilesDir = new File(logFilesDirPath);
 
 		if (!logFilesDir.isDirectory()) {
 			return;

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -188,16 +188,18 @@ public class CompanyLogServlet extends HttpServlet {
 
 		printWriter.println("<html><body>");
 
+		StringBundler sb = new StringBundler();
+
 		if (permissionChecker.isOmniadmin()) {
 			_companyLocalService.forEachCompany(
 				company -> _listCompanyLogFiles(
-					httpServletRequest, printWriter, company));
+					httpServletRequest, sb, company));
 		}
 		else if (permissionChecker.isCompanyAdmin()) {
 			User user = permissionChecker.getUser();
 
 			_listCompanyLogFiles(
-				httpServletRequest, printWriter,
+				httpServletRequest, sb,
 				_companyLocalService.getCompany(user.getCompanyId()));
 		}
 		else {
@@ -205,11 +207,16 @@ public class CompanyLogServlet extends HttpServlet {
 				permissionChecker.getUserId());
 		}
 
+		if (sb.length() == 0) {
+			sb.append("No log is available.");
+		}
+
+		printWriter.println(sb.toString());
 		printWriter.println("</body></html>");
 	}
 
 	private void _listCompanyLogFiles(
-		HttpServletRequest httpServletRequest, PrintWriter printWriter,
+		HttpServletRequest httpServletRequest, StringBundler sb,
 		Company company) {
 
 		String logFilesDirPath = Log4JUtil.getCompanyLogDirectory(
@@ -225,8 +232,9 @@ public class CompanyLogServlet extends HttpServlet {
 			return;
 		}
 
-		printWriter.println("<h1>" + company.getWebId() + "</h1>");
-		printWriter.println("<ul>");
+		sb.append("<h1>");
+		sb.append(company.getWebId());
+		sb.append("</h1><ul>");
 
 		for (File file : logFilesDir.listFiles()) {
 			String href = StringBundler.concat(
@@ -234,15 +242,14 @@ public class CompanyLogServlet extends HttpServlet {
 				_portal.getPathContext(), "/o/company-log/",
 				company.getCompanyId(), StringPool.SLASH, file.getName());
 
-			printWriter.println(
-				"<li><a target=\"_self\" href=\"" + href + "\">");
-
-			printWriter.println(file.getName());
-			printWriter.println("</a>");
-			printWriter.println("</li>");
+			sb.append("<li><a target=\"_self\" href=\"");
+			sb.append(href);
+			sb.append("\">");
+			sb.append(file.getName());
+			sb.append("</a></li>");
 		}
 
-		printWriter.println("</ul>");
+		sb.append("</ul>");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -177,14 +177,14 @@ public class CompanyLogServlet extends HttpServlet {
 				start = GetterUtil.getIntegerStrict(startIndex);
 			}
 
-			long end = 0;
+			long end = logFile.length();
 
 			if (Validator.isNotNull(endIndex)) {
-				end = GetterUtil.getIntegerStrict(endIndex);
-			}
+				int parsedEnd = GetterUtil.getIntegerStrict(endIndex);
 
-			if (end > logFile.length()) {
-				end = logFile.length();
+				if (parsedEnd < end) {
+					end = parsedEnd;
+				}
 			}
 
 			if ((start < 0) || (end < 0) || (start >= end)) {

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -177,16 +177,14 @@ public class CompanyLogServlet extends HttpServlet {
 				start = GetterUtil.getIntegerStrict(startIndex);
 			}
 
-			int logFileLength = (int)logFile.length();
-			
 			int end = 0;
 
 			if (Validator.isNotNull(endIndex)) {
 				end = GetterUtil.getIntegerStrict(endIndex);
 			}
 
-			if (end > logFileLength) {
-				end = logFileLength;
+			if (end > (int)logFile.length()) {
+				end = (int)logFile.length();
 			}
 
 			if ((start < 0) || (end < 0) || (start >= end)) {
@@ -200,7 +198,7 @@ public class CompanyLogServlet extends HttpServlet {
 				--start;
 			}
 
-			byte[] bytes = new byte[logFileLength];
+			byte[] bytes = new byte[(int)logFile.length()];
 
 			try (UnsyncBufferedInputStream unsyncBufferedInputStream =
 					new UnsyncBufferedInputStream(new FileInputStream(logFile));

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -202,9 +202,9 @@ public class CompanyLogServlet extends HttpServlet {
 				fileChannel.position(start);
 
 				ServletResponseUtil.sendFile(
-					httpServletRequest, httpServletResponse, logFile.getName(),
+					httpServletRequest, httpServletResponse, fileName,
 					Channels.newInputStream(fileChannel), end - start,
-					_mimeTypes.getContentType(logFile.getName()),
+					_mimeTypes.getContentType(fileName),
 					HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 			}
 		}

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -185,9 +185,7 @@ public class CompanyLogServlet extends HttpServlet {
 
 			int end = GetterUtil.getIntegerStrict(endIndex);
 
-			if ((start < 0) || (end < 0) || ((start == 0) && (end == 0)) ||
-				(start >= end)) {
-
+			if ((start < 0) || (end < 0) || (start >= end)) {
 				throw new PrincipalException(
 					"startIndex or endIndex can not be less than 0, and " +
 						"startIndex can not be greater than or equal to " +

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -46,6 +46,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -166,7 +167,7 @@ public class CompanyLogServlet extends HttpServlet {
 		if (Validator.isNull(startIndex) && Validator.isNull(endIndex)) {
 			ServletResponseUtil.sendFile(
 				httpServletRequest, httpServletResponse, fileName,
-				new FileInputStream(logFile), logFile.length(),
+				Files.newInputStream(logFile.toPath()), logFile.length(),
 				_mimeTypes.getContentType(fileName),
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
@@ -201,8 +202,9 @@ public class CompanyLogServlet extends HttpServlet {
 			byte[] bytes = new byte[(int)logFile.length()];
 
 			try (UnsyncBufferedInputStream unsyncBufferedInputStream =
-					new UnsyncBufferedInputStream(new FileInputStream(logFile));
-				UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+					new UnsyncBufferedInputStream(
+						Files.newInputStream(logFile.toPath()));
+				 UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 					new UnsyncByteArrayOutputStream()) {
 
 				unsyncBufferedInputStream.read(bytes);

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -33,8 +33,10 @@ import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.MimeTypes;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,6 +44,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -155,11 +158,60 @@ public class CompanyLogServlet extends HttpServlet {
 					companyId));
 		}
 
-		ServletResponseUtil.sendFile(
-			httpServletRequest, httpServletResponse, fileName,
-			new FileInputStream(logFile), logFile.length(),
-			_mimeTypes.getContentType(fileName),
-			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		String startIndex = ParamUtil.getString(
+			httpServletRequest, "startIndex");
+		String endIndex = ParamUtil.getString(httpServletRequest, "endIndex");
+
+		if (Validator.isNull(startIndex) && Validator.isNull(endIndex)) {
+			ServletResponseUtil.sendFile(
+				httpServletRequest, httpServletResponse, fileName,
+				new FileInputStream(logFile), logFile.length(),
+				_mimeTypes.getContentType(fileName),
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		}
+		else {
+			if (Validator.isNull(startIndex)) {
+				startIndex = "0";
+			}
+
+			int start = GetterUtil.getIntegerStrict(startIndex);
+
+			int logFileLength = (int)logFile.length();
+
+			if (Validator.isNull(endIndex) && (start >= 0)) {
+				endIndex = String.valueOf(logFileLength);
+			}
+
+			int end = GetterUtil.getIntegerStrict(endIndex);
+
+			if ((start < 0) || (end < 0) || ((start == 0) && (end == 0)) ||
+				(start >= end)) {
+
+				throw new PrincipalException(
+					"startIndex or endIndex can not be less than 0, and " +
+						"startIndex can not be greater than or equal to " +
+							"endIndex");
+			}
+
+			if (end > logFileLength) {
+				end = logFileLength;
+			}
+
+			if (start != 0) {
+				--start;
+			}
+
+			String logFileContent = new String(
+				Files.readAllBytes(logFile.toPath()));
+
+			logFileContent = logFileContent.substring(start, end);
+
+			ServletResponseUtil.sendFile(
+				httpServletRequest, httpServletResponse, logFile.getName(),
+				logFileContent.getBytes(),
+				_mimeTypes.getContentType(logFile.getName()),
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		}
 	}
 
 	private PermissionChecker _getPermissionChecker(

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -178,22 +178,22 @@ public class CompanyLogServlet extends HttpServlet {
 			}
 
 			int logFileLength = (int)logFile.length();
+			
+			int end = 0;
 
-			if (Validator.isNull(endIndex) && (start >= 0)) {
-				endIndex = String.valueOf(logFileLength);
+			if (Validator.isNotNull(endIndex)) {
+				end = GetterUtil.getIntegerStrict(endIndex);
 			}
 
-			int end = GetterUtil.getIntegerStrict(endIndex);
+			if (end > logFileLength) {
+				end = logFileLength;
+			}
 
 			if ((start < 0) || (end < 0) || (start >= end)) {
 				throw new PrincipalException(
 					"startIndex or endIndex can not be less than 0, and " +
 						"startIndex can not be greater than or equal to " +
 							"endIndex");
-			}
-
-			if (end > logFileLength) {
-				end = logFileLength;
 			}
 
 			if (start != 0) {

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -171,20 +171,20 @@ public class CompanyLogServlet extends HttpServlet {
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
-			int start = 0;
+			long start = 0;
 
 			if (Validator.isNotNull(startIndex)) {
 				start = GetterUtil.getIntegerStrict(startIndex);
 			}
 
-			int end = 0;
+			long end = 0;
 
 			if (Validator.isNotNull(endIndex)) {
 				end = GetterUtil.getIntegerStrict(endIndex);
 			}
 
-			if (end > (int)logFile.length()) {
-				end = (int)logFile.length();
+			if (end > logFile.length()) {
+				end = logFile.length();
 			}
 
 			if ((start < 0) || (end < 0) || (start >= end)) {

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.company.log.internal.servlet;
 
+import com.liferay.petra.io.unsync.UnsyncBufferedInputStream;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.log4j.Log4JUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -44,7 +46,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -201,16 +202,23 @@ public class CompanyLogServlet extends HttpServlet {
 				--start;
 			}
 
-			String logFileContent = new String(
-				Files.readAllBytes(logFile.toPath()));
+			byte[] bytes = new byte[logFileLength];
 
-			logFileContent = logFileContent.substring(start, end);
+			try (UnsyncBufferedInputStream unsyncBufferedInputStream =
+					new UnsyncBufferedInputStream(new FileInputStream(logFile));
+				UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+					new UnsyncByteArrayOutputStream()) {
 
-			ServletResponseUtil.sendFile(
-				httpServletRequest, httpServletResponse, logFile.getName(),
-				logFileContent.getBytes(),
-				_mimeTypes.getContentType(logFile.getName()),
-				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+				unsyncBufferedInputStream.read(bytes);
+
+				unsyncByteArrayOutputStream.write(bytes, start, end - start);
+
+				ServletResponseUtil.sendFile(
+					httpServletRequest, httpServletResponse, logFile.getName(),
+					unsyncByteArrayOutputStream.toByteArray(),
+					_mimeTypes.getContentType(logFile.getName()),
+					HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+			}
 		}
 	}
 

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -171,11 +171,11 @@ public class CompanyLogServlet extends HttpServlet {
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
-			if (Validator.isNull(startIndex)) {
-				startIndex = "0";
-			}
+			int start = 0;
 
-			int start = GetterUtil.getIntegerStrict(startIndex);
+			if (Validator.isNotNull(startIndex)) {
+				start = GetterUtil.getIntegerStrict(startIndex);
+			}
 
 			int logFileLength = (int)logFile.length();
 

--- a/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
+++ b/modules/apps/portal/portal-company-log/src/main/java/com/liferay/portal/company/log/internal/servlet/CompanyLogServlet.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.company.log.internal.servlet;
 
-import com.liferay.petra.io.unsync.UnsyncBufferedInputStream;
-import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.log4j.Log4JUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -41,11 +39,12 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -199,21 +198,12 @@ public class CompanyLogServlet extends HttpServlet {
 				--start;
 			}
 
-			byte[] bytes = new byte[(int)logFile.length()];
-
-			try (UnsyncBufferedInputStream unsyncBufferedInputStream =
-					new UnsyncBufferedInputStream(
-						Files.newInputStream(logFile.toPath()));
-				 UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-					new UnsyncByteArrayOutputStream()) {
-
-				unsyncBufferedInputStream.read(bytes);
-
-				unsyncByteArrayOutputStream.write(bytes, start, end - start);
+			try (FileChannel fileChannel = FileChannel.open(logFile.toPath())) {
+				fileChannel.position(start);
 
 				ServletResponseUtil.sendFile(
 					httpServletRequest, httpServletResponse, logFile.getName(),
-					unsyncByteArrayOutputStream.toByteArray(),
+					Channels.newInputStream(fileChannel), end - start,
 					_mimeTypes.getContentType(logFile.getName()),
 					HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -403,7 +403,8 @@ public class ServletResponseUtil {
 
 		try {
 			StreamUtil.transfer(
-				inputStream, httpServletResponse.getOutputStream());
+				inputStream, httpServletResponse.getOutputStream(),
+				contentLength);
 		}
 		catch (IOException ioException) {
 			_checkSocketException(ioException);


### PR DESCRIPTION
- LPS-154230 Add Servlet to support browsing of the log files for companies. When clicking the log file, the file will be downloaded.
- LPS-154230 CompanyLogServlet only is registered if the property company.log.enabled=true
- LPS-154230 Reuse the permission checker
- LPS-154230 Iterate log files in all companies when the user is omni-admin, otherwise, only list log files of the user's company
- LPS-154230 SF
- LPS-154230 Push down permission checking
- LPS-154230 SF, don't use Document Library exception
- LPS-154230 SF, not used
- LPS-154230 Expose one method to return specific company's log directory.
- LPS-154230 Apply
- LPS-154230 SF, move logic to CentralizedConfiguration
- LPS-154230 Make sure _companyLogRoutingAppender populated correctly and thread safe
- LPS-154230 SF, simplify
- LPS-154230 Print message when there is no log available instead of returning a blank page.
- LPS-154230 No need to do null checking, instanceof checking will fail if null
- LPS-154230 Use Path instead to avoid dealing with path separator
- LPS-154230 Add test (Log4jConfigUtilTest is full coverage test).
- LPS-154230 baseline
- LPS-154230 More detailed message when file is not found
- LPS-154230 Display file size.
- LPS-154230 Add the function about downloading file content by range in UI.
- LPS-154230 SF
- LPS-154230 Download the log file by using input startIndex and endIndex. If the user doesn't input any values in startIndex and endIndex <input>, directly download the log file. If the user inputs “0” in startIndex and doesn't input any value in endIndex, it will download the entire log file.
- LPS-154230 Files.readAllBytes() is not intended for reading in large files. Use our API UnsyncBufferedInputStream and UnsyncByteArrayOutputStream to read/write the large files.
- LPS-154230 Add servlet integration test.
- LPS-154230 SF, extract the common logic to private method.
- LPS-154230 Project files
- LPS-154230 SF, directly assign the int value
- LPS-154230 SF, remove redundant condition as it's covered by "start >= end"
- LPS-154230 SF, directly assign the int value
- LPS-154230 SF, inline, prepare for next
- LPS-154230 SF, suggested by IntelliJ IDEA
- LPS-154230 When content length is provided, ServletResponseUtil should honor it
- LPS-154230 Send the file with start position and length
- LPS-154230 Should use long for file size & position
- LPS-154230 Proper logic to set end index
- LPS-154230 Proper filename
