### PR TITLE
[DB2-issue] LPS-112222

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -343,7 +343,7 @@
     database.db2.service.cmd.stop=db2stop force
     database.db2.service.executable=db2
     database.db2.username=root
-    database.db2.url=jdbc:db2://${database.db2.host}:50000/${database.db2.schema}:deferPrepares=false;fullyMaterializeInputStreams=true;fullyMaterializeLobData=true;progresssiveLocators=2;progressiveStreaming=2;
+    database.db2.url=jdbc:db2://${database.db2.host}:50000/${database.db2.schema}:currentSchema=ROOT;deferPrepares=false;fullyMaterializeInputStreams=true;fullyMaterializeLobData=true;progresssiveLocators=2;progressiveStreaming=2;
     database.db2.version=11.1.3
     database.db2.version.cmd=db2level
 

--- a/test.properties
+++ b/test.properties
@@ -3869,8 +3869,7 @@
     test.batch.dist.app.servers[environments]=tomcat
 
     test.batch.names[environments]=\
-        functional-tomcat90-db2111-jdk8,\
-        functional-tomcat90-db2115-jdk8
+        functional-tomcat90-db2111-jdk8
 
     test.batch.run.property.query[functional-alpine*][environments]=\
         portal.smoke == true

--- a/test.properties
+++ b/test.properties
@@ -2804,7 +2804,7 @@
     test.batch.names[acceptance-dxp]=\
         ${test.batch.names[acceptance-ce]},\
         functional-smoke-tomcat90-db2111-jdk8,\
-        #functional-smoke-tomcat90-db2115-jdk8,\
+        functional-smoke-tomcat90-db2115-jdk8,\
         functional-smoke-tomcat90-oracle193-jdk8,\
         functional-smoke-tomcat90-sqlserver2017-jdk8,\
         functional-smoke-tomcat90-sqlserver2019-jdk8,\
@@ -3878,7 +3878,7 @@
         functional-redhat8-tomcat90-mysql57-jdk8,\
         functional-suse15-tomcat90-mysql57-jdk8,\
         functional-tomcat90-db2111-jdk8,\
-        #functional-tomcat90-db2115-jdk8,\
+        functional-tomcat90-db2115-jdk8,\
         functional-tomcat90-mariadb102-jdk8,\
         functional-tomcat90-mysql57-jdk8_redhat,\
         functional-tomcat90-mysql57-jdk8_zulu,\
@@ -4157,7 +4157,7 @@
         functional-smoke-jboss73-mysql57-jdk8,\
         functional-smoke-jboss74-mysql57-jdk8,\
         functional-smoke-tomcat90-db2111-jdk8,\
-        #functional-smoke-tomcat90-db2115-jdk8,\
+        functional-smoke-tomcat90-db2115-jdk8,\
         functional-smoke-tomcat90-mariadb102-jdk8,\
         functional-smoke-tomcat90-mysql57-jdk8,\
         functional-smoke-tomcat90-mysql57-jdk11_open,\
@@ -4320,7 +4320,7 @@
         functional-smoke-jboss73-mysql57-jdk11_open,\
         functional-smoke-jboss74-mysql57-jdk11_open,\
         functional-smoke-tomcat90-db2111-jdk11_open,\
-        #functional-smoke-tomcat90-db2115-jdk11_open,\
+        functional-smoke-tomcat90-db2115-jdk11_open,\
         functional-smoke-tomcat90-mariadb102-jdk11_open,\
         functional-smoke-tomcat90-mysql57-jdk11_open,\
         functional-smoke-tomcat90-mysql80-jdk11_open,\
@@ -5480,7 +5480,7 @@
         functional-bundle-tomcat-mysql57-jdk8,\
         functional-smoke-bundle-jboss-mysql57-jdk8,\
         functional-smoke-bundle-tomcat-db2111-jdk8,\
-        #functional-smoke-bundle-tomcat-db2115-jdk8,\
+        functional-smoke-bundle-tomcat-db2115-jdk8,\
         functional-smoke-bundle-tomcat-hypersonic20-jdk8,\
         functional-smoke-bundle-tomcat-mariadb102-jdk8,\
         functional-smoke-bundle-tomcat-mysql57-jdk11_open,\
@@ -5811,7 +5811,7 @@
         functional-bundle-redhat8-tomcat90-mysql57-jdk8,\
         functional-bundle-suse15-tomcat90-mysql57-jdk8,\
         functional-bundle-tomcat-db2111-jdk8,\
-        #functional-bundle-tomcat-db2115-jdk8,\
+        functional-bundle-tomcat-db2115-jdk8,\
         functional-bundle-tomcat-mariadb104-jdk8,\
         functional-bundle-tomcat-mariadb106-jdk8,\
         functional-bundle-tomcat-mysql57-jdk8_redhat,\
@@ -6300,7 +6300,7 @@
         functional-jboss73-mysql57-jdk8,\
         functional-jboss74-mysql57-jdk8,\
         functional-tomcat90-db2111-jdk8,\
-        #functional-tomcat90-db2115-jdk8,\
+        functional-tomcat90-db2115-jdk8,\
         functional-tomcat90-hypersonic20-jdk8,\
         functional-tomcat90-mariadb104-jdk8,\
         functional-tomcat90-mariadb106-jdk8,\
@@ -6753,7 +6753,7 @@
         functional-redhat8-tomcat90-mysql57-jdk8,\
         functional-suse15-tomcat90-mysql57-jdk8,\
         functional-tomcat90-db2111-jdk8,\
-        #functional-tomcat90-db2115-jdk8,\
+        functional-tomcat90-db2115-jdk8,\
         functional-tomcat90-hypersonic20-jdk8,\
         functional-tomcat90-mariadb104-jdk8,\
         functional-tomcat90-mariadb106-jdk8,\
@@ -7408,7 +7408,7 @@
         functional-upgrade-jboss73-mysql57-jdk8,\
         functional-upgrade-jboss74-mysql57-jdk8,\
         functional-upgrade-tomcat90-db2111-jdk8,\
-        #functional-upgrade-tomcat90-db2115-jdk8,\
+        functional-upgrade-tomcat90-db2115-jdk8,\
         functional-upgrade-tomcat90-mariadb102-jdk8,\
         functional-upgrade-tomcat90-mariadb104-jdk8,\
         functional-upgrade-tomcat90-mariadb106-jdk8,\
@@ -7540,7 +7540,7 @@
     test.batch.names[upstream-dxp]=\
         database-upgrade-client-jdk8,\
         functional-tomcat90-db2111-jdk8,\
-        #functional-tomcat90-db2115-jdk8,\
+        functional-tomcat90-db2115-jdk8,\
         functional-tomcat90-hypersonic20-jdk8,\
         functional-tomcat90-mariadb102-jdk8,\
         functional-tomcat90-mysql57-jdk8,\
@@ -7551,7 +7551,7 @@
         functional-upgrade-jboss73-mysql57-jdk8,\
         functional-upgrade-jboss74-mysql57-jdk8,\
         functional-upgrade-tomcat90-db2111-jdk8,\
-        #functional-upgrade-tomcat90-db2115-jdk8,\
+        functional-upgrade-tomcat90-db2115-jdk8,\
         functional-upgrade-tomcat90-mariadb102-jdk8,\
         functional-upgrade-tomcat90-oracle193-jdk8,\
         functional-upgrade-tomcat90-postgresql121-jdk8,\

--- a/test.properties
+++ b/test.properties
@@ -3866,39 +3866,11 @@
     # Environments
     #
 
-    test.batch.dist.app.servers[environments]=${test.batch.dist.app.servers}
+    test.batch.dist.app.servers[environments]=tomcat
 
     test.batch.names[environments]=\
-        functional-alpine310-tomcat90-mysql57-jdk8,\
-        functional-centos8-tomcat90-mysql57-jdk8,\
-        functional-jboss73-mysql57-jdk8,\
-        functional-jboss74-mysql57-jdk8,\
-        functional-orcllinux7-tomcat90-mysql57-jdk8,\
-        functional-orcllinux8-tomcat90-mysql57-jdk8,\
-        functional-redhat8-tomcat90-mysql57-jdk8,\
-        functional-suse15-tomcat90-mysql57-jdk8,\
         functional-tomcat90-db2111-jdk8,\
-        functional-tomcat90-db2115-jdk8,\
-        functional-tomcat90-mariadb102-jdk8,\
-        functional-tomcat90-mysql57-jdk8_redhat,\
-        functional-tomcat90-mysql57-jdk8_zulu,\
-        functional-tomcat90-mysql57-jdk11_open,\
-        functional-tomcat90-mysql57-jdk11_oracle,\
-        functional-tomcat90-mysql57-jdk11_zulu,\
-        functional-tomcat90-mysql80-jdk8,\
-        functional-tomcat90-oracle193-jdk8,\
-        functional-tomcat90-postgresql134-jdk8,\
-        functional-tomcat90-postgresql144-jdk8,\
-        functional-ubuntu18-tomcat90-mysql57-jdk8,\
-        functional-ubuntu20-tomcat90-mysql57-jdk8,\
-        functional-ubuntu22-tomcat90-mysql57-jdk8,\
-        functional-weblogic122-mysql57-jdk8,\
-        functional-weblogic141-mysql57-jdk8,\
-        functional-websphere90-mysql57-jdk8,\
-        functional-wildfly180-mariadb104-jdk8,\
-        functional-wildfly180-mariadb106-jdk8,\
-        functional-wildfly230-mariadb104-jdk8,\
-        functional-wildfly230-mariadb106-jdk8
+        functional-tomcat90-db2115-jdk8
 
     test.batch.run.property.query[functional-alpine*][environments]=\
         portal.smoke == true


### PR DESCRIPTION
@zhangyan0701, set currentSchema with upper case. Refer to https://stackoverflow.com/questions/24144538/why-do-i-get-sqlcode-204-sqlstate-42704-with-db2-luw-and-websphere-app-server. I think we may check db11.1 test result. DB 11.5 might be not upper case.

The attempt reason is schemas are upper case when I execute the command "db2 select schemaname from syscat.schemata" in db2.