### PR TITLE
[Remove Spring extender usages]  LPS-161574 Break circular dependency between CommerceAddressLocalServiceImpl and CommerceOrderLocalServiceImpl

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -549,6 +549,22 @@ public interface CommerceOrderLocalService
 			long commerceOrderId, CommerceContext commerceContext)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
+	public CommerceOrder removeCommerceOrderBillingAddress(
+			CommerceOrder commerceOrder)
+		throws PortalException;
+
+	public void removeCommerceOrderBillingAddress(long billingAddressId)
+		throws PortalException;
+
+	@Indexable(type = IndexableType.REINDEX)
+	public CommerceOrder removeCommerceOrderShippingAddress(
+			CommerceOrder commerceOrder)
+		throws PortalException;
+
+	public void removeCommerceOrderShippingAddress(long shippingAddressId)
+		throws PortalException;
+
 	public CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId, CommerceContext commerceContext)
 		throws PortalException;

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -554,7 +554,10 @@ public interface CommerceOrderLocalService
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
-	public CommerceOrder resetCommerceOrderShipping(long commerceOrderId)
+	public CommerceOrder resetCommerceOrderShipping(CommerceOrder commerceOrder)
+		throws PortalException;
+
+	public void resetCommerceOrderShipping(long shippingAddressId)
 		throws PortalException;
 
 	public CommerceOrder resetTermsAndConditions(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -750,7 +750,6 @@ public interface CommerceOrderLocalService
 			long commerceOrderId, long shippingAddressId)
 		throws PortalException;
 
-	@Indexable(type = IndexableType.REINDEX)
 	public CommerceOrder updateShippingAddress(
 			long commerceOrderId, String name, String description,
 			String street1, String street2, String street3, String city,

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -728,10 +728,17 @@ public class CommerceOrderLocalServiceUtil {
 			userId, commerceOrderId, commerceContext);
 	}
 
-	public static CommerceOrder resetCommerceOrderShipping(long commerceOrderId)
+	public static CommerceOrder resetCommerceOrderShipping(
+			CommerceOrder commerceOrder)
 		throws PortalException {
 
-		return getService().resetCommerceOrderShipping(commerceOrderId);
+		return getService().resetCommerceOrderShipping(commerceOrder);
+	}
+
+	public static void resetCommerceOrderShipping(long shippingAddressId)
+		throws PortalException {
+
+		getService().resetCommerceOrderShipping(shippingAddressId);
 	}
 
 	public static CommerceOrder resetTermsAndConditions(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -719,6 +719,33 @@ public class CommerceOrderLocalServiceUtil {
 		return getService().recalculatePrice(commerceOrderId, commerceContext);
 	}
 
+	public static CommerceOrder removeCommerceOrderBillingAddress(
+			CommerceOrder commerceOrder)
+		throws PortalException {
+
+		return getService().removeCommerceOrderBillingAddress(commerceOrder);
+	}
+
+	public static void removeCommerceOrderBillingAddress(long billingAddressId)
+		throws PortalException {
+
+		getService().removeCommerceOrderBillingAddress(billingAddressId);
+	}
+
+	public static CommerceOrder removeCommerceOrderShippingAddress(
+			CommerceOrder commerceOrder)
+		throws PortalException {
+
+		return getService().removeCommerceOrderShippingAddress(commerceOrder);
+	}
+
+	public static void removeCommerceOrderShippingAddress(
+			long shippingAddressId)
+		throws PortalException {
+
+		getService().removeCommerceOrderShippingAddress(shippingAddressId);
+	}
+
 	public static CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId,
 			com.liferay.commerce.context.CommerceContext commerceContext)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -817,6 +817,42 @@ public class CommerceOrderLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.commerce.model.CommerceOrder
+			removeCommerceOrderBillingAddress(
+				com.liferay.commerce.model.CommerceOrder commerceOrder)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceOrderLocalService.removeCommerceOrderBillingAddress(
+			commerceOrder);
+	}
+
+	@Override
+	public void removeCommerceOrderBillingAddress(long billingAddressId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_commerceOrderLocalService.removeCommerceOrderBillingAddress(
+			billingAddressId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceOrder
+			removeCommerceOrderShippingAddress(
+				com.liferay.commerce.model.CommerceOrder commerceOrder)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceOrderLocalService.removeCommerceOrderShippingAddress(
+			commerceOrder);
+	}
+
+	@Override
+	public void removeCommerceOrderShippingAddress(long shippingAddressId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_commerceOrderLocalService.removeCommerceOrderShippingAddress(
+			shippingAddressId);
+	}
+
+	@Override
 	public com.liferay.commerce.model.CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId,
 			com.liferay.commerce.context.CommerceContext commerceContext)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -828,11 +828,19 @@ public class CommerceOrderLocalServiceWrapper
 
 	@Override
 	public com.liferay.commerce.model.CommerceOrder resetCommerceOrderShipping(
-			long commerceOrderId)
+			com.liferay.commerce.model.CommerceOrder commerceOrder)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderLocalService.resetCommerceOrderShipping(
-			commerceOrderId);
+			commerceOrder);
+	}
+
+	@Override
+	public void resetCommerceOrderShipping(long shippingAddressId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_commerceOrderLocalService.resetCommerceOrderShipping(
+			shippingAddressId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderService.java
@@ -263,6 +263,9 @@ public interface CommerceOrderService extends BaseService {
 			long commerceOrderId, CommerceContext commerceContext)
 		throws PortalException;
 
+	public void resetCommerceOrderShipping(long commerceOrderId)
+		throws PortalException;
+
 	public CommerceOrder resetTermsAndConditions(
 			long commerceOrderId, boolean deliveryCommerceTermEntry,
 			boolean paymentCommerceTermEntry)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceUtil.java
@@ -370,6 +370,12 @@ public class CommerceOrderServiceUtil {
 			commerceOrderId, commerceContext);
 	}
 
+	public static void resetCommerceOrderShipping(long commerceOrderId)
+		throws PortalException {
+
+		getService().resetCommerceOrderShipping(commerceOrderId);
+	}
+
 	public static CommerceOrder resetTermsAndConditions(
 			long commerceOrderId, boolean deliveryCommerceTermEntry,
 			boolean paymentCommerceTermEntry)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceWrapper.java
@@ -426,6 +426,13 @@ public class CommerceOrderServiceWrapper
 	}
 
 	@Override
+	public void resetCommerceOrderShipping(long commerceOrderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_commerceOrderService.resetCommerceOrderShipping(commerceOrderId);
+	}
+
+	@Override
 	public com.liferay.commerce.model.CommerceOrder resetTermsAndConditions(
 			long commerceOrderId, boolean deliveryCommerceTermEntry,
 			boolean paymentCommerceTermEntry)

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderServiceHttp.java
@@ -1547,6 +1547,42 @@ public class CommerceOrderServiceHttp {
 		}
 	}
 
+	public static void resetCommerceOrderShipping(
+			HttpPrincipal httpPrincipal, long commerceOrderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CommerceOrderServiceUtil.class, "resetCommerceOrderShipping",
+				_resetCommerceOrderShippingParameterTypes35);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, commerceOrderId);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.commerce.model.CommerceOrder
 			resetTermsAndConditions(
 				HttpPrincipal httpPrincipal, long commerceOrderId,
@@ -1557,7 +1593,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "resetTermsAndConditions",
-				_resetTermsAndConditionsParameterTypes35);
+				_resetTermsAndConditionsParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, deliveryCommerceTermEntry,
@@ -1599,7 +1635,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateBillingAddress",
-				_updateBillingAddressParameterTypes36);
+				_updateBillingAddressParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, billingAddressId);
@@ -1643,7 +1679,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateBillingAddress",
-				_updateBillingAddressParameterTypes37);
+				_updateBillingAddressParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, name, description, street1, street2,
@@ -1686,7 +1722,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateCommerceOrder",
-				_updateCommerceOrderParameterTypes38);
+				_updateCommerceOrderParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrder);
@@ -1738,7 +1774,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateCommerceOrder",
-				_updateCommerceOrderParameterTypes39);
+				_updateCommerceOrderParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, commerceOrderId,
@@ -1790,7 +1826,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateCommerceOrder",
-				_updateCommerceOrderParameterTypes40);
+				_updateCommerceOrderParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, commerceOrderId,
@@ -1837,7 +1873,7 @@ public class CommerceOrderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class,
 				"updateCommerceOrderExternalReferenceCode",
-				_updateCommerceOrderExternalReferenceCodeParameterTypes41);
+				_updateCommerceOrderExternalReferenceCodeParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, commerceOrderId);
@@ -1896,7 +1932,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateCommerceOrderPrices",
-				_updateCommerceOrderPricesParameterTypes42);
+				_updateCommerceOrderPricesParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, shippingAmount,
@@ -1992,7 +2028,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateCommerceOrderPrices",
-				_updateCommerceOrderPricesParameterTypes43);
+				_updateCommerceOrderPricesParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, shippingAmount,
@@ -2061,7 +2097,7 @@ public class CommerceOrderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class,
 				"updateCommercePaymentMethodKey",
-				_updateCommercePaymentMethodKeyParameterTypes44);
+				_updateCommercePaymentMethodKeyParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, commercePaymentMethodKey);
@@ -2106,7 +2142,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateCommerceShippingMethod",
-				_updateCommerceShippingMethodParameterTypes45);
+				_updateCommerceShippingMethodParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, commerceShippingMethodId,
@@ -2151,7 +2187,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateInfo",
-				_updateInfoParameterTypes46);
+				_updateInfoParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, printedNote,
@@ -2197,7 +2233,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateOrderDate",
-				_updateOrderDateParameterTypes47);
+				_updateOrderDateParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, orderDateMonth, orderDateDay,
@@ -2239,7 +2275,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updatePaymentStatus",
-				_updatePaymentStatusParameterTypes48);
+				_updatePaymentStatusParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, paymentStatus);
@@ -2282,7 +2318,7 @@ public class CommerceOrderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class,
 				"updatePaymentStatusAndTransactionId",
-				_updatePaymentStatusAndTransactionIdParameterTypes49);
+				_updatePaymentStatusAndTransactionIdParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, paymentStatus, transactionId);
@@ -2323,7 +2359,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updatePrintedNote",
-				_updatePrintedNoteParameterTypes50);
+				_updatePrintedNoteParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, printedNote);
@@ -2365,7 +2401,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updatePurchaseOrderNumber",
-				_updatePurchaseOrderNumberParameterTypes51);
+				_updatePurchaseOrderNumberParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, purchaseOrderNumber);
@@ -2407,7 +2443,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateShippingAddress",
-				_updateShippingAddressParameterTypes52);
+				_updateShippingAddressParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, shippingAddressId);
@@ -2452,7 +2488,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateShippingAddress",
-				_updateShippingAddressParameterTypes53);
+				_updateShippingAddressParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, name, description, street1, street2,
@@ -2497,7 +2533,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "updateTermsAndConditions",
-				_updateTermsAndConditionsParameterTypes54);
+				_updateTermsAndConditionsParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId, deliveryCommerceTermEntryId,
@@ -2669,19 +2705,21 @@ public class CommerceOrderServiceHttp {
 		new Class[] {
 			long.class, com.liferay.commerce.context.CommerceContext.class
 		};
-	private static final Class<?>[] _resetTermsAndConditionsParameterTypes35 =
+	private static final Class<?>[]
+		_resetCommerceOrderShippingParameterTypes35 = new Class[] {long.class};
+	private static final Class<?>[] _resetTermsAndConditionsParameterTypes36 =
 		new Class[] {long.class, boolean.class, boolean.class};
-	private static final Class<?>[] _updateBillingAddressParameterTypes36 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _updateBillingAddressParameterTypes37 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _updateBillingAddressParameterTypes38 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class, String.class, long.class, long.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCommerceOrderParameterTypes38 =
-		new Class[] {com.liferay.commerce.model.CommerceOrder.class};
 	private static final Class<?>[] _updateCommerceOrderParameterTypes39 =
+		new Class[] {com.liferay.commerce.model.CommerceOrder.class};
+	private static final Class<?>[] _updateCommerceOrderParameterTypes40 =
 		new Class[] {
 			String.class, long.class, long.class, long.class, long.class,
 			String.class, String.class, String.class,
@@ -2692,7 +2730,7 @@ public class CommerceOrderServiceHttp {
 			java.math.BigDecimal.class,
 			com.liferay.commerce.context.CommerceContext.class
 		};
-	private static final Class<?>[] _updateCommerceOrderParameterTypes40 =
+	private static final Class<?>[] _updateCommerceOrderParameterTypes41 =
 		new Class[] {
 			String.class, long.class, long.class, long.class, long.class,
 			String.class, String.class, String.class,
@@ -2701,21 +2739,8 @@ public class CommerceOrderServiceHttp {
 			com.liferay.commerce.context.CommerceContext.class
 		};
 	private static final Class<?>[]
-		_updateCommerceOrderExternalReferenceCodeParameterTypes41 =
+		_updateCommerceOrderExternalReferenceCodeParameterTypes42 =
 			new Class[] {String.class, long.class};
-	private static final Class<?>[] _updateCommerceOrderPricesParameterTypes42 =
-		new Class[] {
-			long.class, java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class, java.math.BigDecimal.class,
-			java.math.BigDecimal.class
-		};
 	private static final Class<?>[] _updateCommerceOrderPricesParameterTypes43 =
 		new Class[] {
 			long.class, java.math.BigDecimal.class, java.math.BigDecimal.class,
@@ -2727,6 +2752,19 @@ public class CommerceOrderServiceHttp {
 			java.math.BigDecimal.class, java.math.BigDecimal.class,
 			java.math.BigDecimal.class, java.math.BigDecimal.class,
 			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class
+		};
+	private static final Class<?>[] _updateCommerceOrderPricesParameterTypes44 =
+		new Class[] {
+			long.class, java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
+			java.math.BigDecimal.class, java.math.BigDecimal.class,
 			java.math.BigDecimal.class, java.math.BigDecimal.class,
 			java.math.BigDecimal.class, java.math.BigDecimal.class,
 			java.math.BigDecimal.class, java.math.BigDecimal.class,
@@ -2739,43 +2777,43 @@ public class CommerceOrderServiceHttp {
 			java.math.BigDecimal.class
 		};
 	private static final Class<?>[]
-		_updateCommercePaymentMethodKeyParameterTypes44 = new Class[] {
+		_updateCommercePaymentMethodKeyParameterTypes45 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_updateCommerceShippingMethodParameterTypes45 = new Class[] {
+		_updateCommerceShippingMethodParameterTypes46 = new Class[] {
 			long.class, long.class, String.class,
 			com.liferay.commerce.context.CommerceContext.class,
 			java.util.Locale.class
 		};
-	private static final Class<?>[] _updateInfoParameterTypes46 = new Class[] {
+	private static final Class<?>[] _updateInfoParameterTypes47 = new Class[] {
 		long.class, String.class, int.class, int.class, int.class, int.class,
 		int.class, com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _updateOrderDateParameterTypes47 =
+	private static final Class<?>[] _updateOrderDateParameterTypes48 =
 		new Class[] {
 			long.class, int.class, int.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updatePaymentStatusParameterTypes48 =
+	private static final Class<?>[] _updatePaymentStatusParameterTypes49 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_updatePaymentStatusAndTransactionIdParameterTypes49 = new Class[] {
+		_updatePaymentStatusAndTransactionIdParameterTypes50 = new Class[] {
 			long.class, int.class, String.class
 		};
-	private static final Class<?>[] _updatePrintedNoteParameterTypes50 =
+	private static final Class<?>[] _updatePrintedNoteParameterTypes51 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updatePurchaseOrderNumberParameterTypes51 =
+	private static final Class<?>[] _updatePurchaseOrderNumberParameterTypes52 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updateShippingAddressParameterTypes52 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _updateShippingAddressParameterTypes53 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _updateShippingAddressParameterTypes54 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class, String.class, long.class, long.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateTermsAndConditionsParameterTypes54 =
+	private static final Class<?>[] _updateTermsAndConditionsParameterTypes55 =
 		new Class[] {long.class, long.class, long.class, String.class};
 
 }

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -576,17 +576,6 @@ public class CommerceAddressLocalServiceImpl
 			CommerceAddressImpl.toAddressTypeId(type), address.isMailing(),
 			address.isPrimary(), phoneNumber);
 
-		// Commerce orders
-
-		List<CommerceOrder> commerceOrders =
-			commerceOrderLocalService.getCommerceOrdersByShippingAddress(
-				commerceAddressId);
-
-		for (CommerceOrder commerceOrder : commerceOrders) {
-			commerceOrderLocalService.resetCommerceOrderShipping(
-				commerceOrder.getCommerceOrderId());
-		}
-
 		return CommerceAddressImpl.fromAddress(address);
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -23,7 +23,6 @@ import com.liferay.commerce.exception.CommerceAddressTypeException;
 import com.liferay.commerce.exception.CommerceAddressZipException;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.model.CommerceGeocoder;
-import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.model.impl.CommerceAddressImpl;
 import com.liferay.commerce.service.base.CommerceAddressLocalServiceBaseImpl;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -33,8 +32,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
-import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.AddressLocalService;
@@ -46,8 +43,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.vulcan.util.TransformUtil;
-
-import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -170,19 +165,11 @@ public class CommerceAddressLocalServiceImpl
 
 		// Commerce orders
 
-		List<CommerceOrder> commerceOrders =
-			commerceOrderLocalService.getCommerceOrdersByBillingAddress(
-				commerceAddress.getCommerceAddressId());
+		commerceOrderLocalService.removeCommerceOrderBillingAddress(
+			commerceAddress.getCommerceAddressId());
 
-		removeCommerceOrderAddresses(
-			commerceOrders, commerceAddress.getCommerceAddressId());
-
-		commerceOrders =
-			commerceOrderLocalService.getCommerceOrdersByShippingAddress(
-				commerceAddress.getCommerceAddressId());
-
-		removeCommerceOrderAddresses(
-			commerceOrders, commerceAddress.getCommerceAddressId());
+		commerceOrderLocalService.removeCommerceOrderShippingAddress(
+			commerceAddress.getCommerceAddressId());
 
 		return commerceAddress;
 	}
@@ -579,36 +566,6 @@ public class CommerceAddressLocalServiceImpl
 			address.isPrimary(), phoneNumber);
 
 		return CommerceAddressImpl.fromAddress(address);
-	}
-
-	protected void removeCommerceOrderAddresses(
-			List<CommerceOrder> commerceOrders, long commerceAddressId)
-		throws PortalException {
-
-		for (CommerceOrder commerceOrder : commerceOrders) {
-			long billingAddressId = commerceOrder.getBillingAddressId();
-			long shippingAddressId = commerceOrder.getShippingAddressId();
-
-			if (billingAddressId == commerceAddressId) {
-				commerceOrder.setBillingAddressId(0);
-			}
-
-			if (shippingAddressId == commerceAddressId) {
-				commerceOrder.setShippingAddressId(0);
-				commerceOrder.setCommerceShippingMethodId(0);
-				commerceOrder.setShippingOptionName(null);
-				commerceOrder.setShippingAmount(BigDecimal.ZERO);
-			}
-
-			commerceOrder = commerceOrderPersistence.update(commerceOrder);
-
-			Indexer<CommerceOrder> indexer =
-				IndexerRegistryUtil.nullSafeGetIndexer(CommerceOrder.class);
-
-			indexer.reindex(
-				CommerceOrder.class.getName(),
-				commerceOrder.getCommerceOrderId());
-		}
 	}
 
 	protected void validate(

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -163,14 +163,6 @@ public class CommerceAddressLocalServiceImpl
 		_addressLocalService.deleteAddress(
 			commerceAddress.getCommerceAddressId());
 
-		// Commerce orders
-
-		commerceOrderLocalService.removeCommerceOrderBillingAddress(
-			commerceAddress.getCommerceAddressId());
-
-		commerceOrderLocalService.removeCommerceOrderShippingAddress(
-			commerceAddress.getCommerceAddressId());
-
 		return commerceAddress;
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -33,6 +33,8 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.AddressLocalService;
@@ -587,31 +589,25 @@ public class CommerceAddressLocalServiceImpl
 			long billingAddressId = commerceOrder.getBillingAddressId();
 			long shippingAddressId = commerceOrder.getShippingAddressId();
 
-			long commerceShippingMethodId =
-				commerceOrder.getCommerceShippingMethodId();
-			String shippingOptionName = commerceOrder.getShippingOptionName();
-			BigDecimal shippingPrice = commerceOrder.getShippingAmount();
-
 			if (billingAddressId == commerceAddressId) {
-				billingAddressId = 0;
+				commerceOrder.setBillingAddressId(0);
 			}
 
 			if (shippingAddressId == commerceAddressId) {
-				shippingAddressId = 0;
-
-				commerceShippingMethodId = 0;
-				shippingOptionName = null;
-				shippingPrice = BigDecimal.ZERO;
+				commerceOrder.setShippingAddressId(0);
+				commerceOrder.setCommerceShippingMethodId(0);
+				commerceOrder.setShippingOptionName(null);
+				commerceOrder.setShippingAmount(BigDecimal.ZERO);
 			}
 
-			commerceOrderLocalService.updateCommerceOrder(
-				null, commerceOrder.getCommerceOrderId(), billingAddressId,
-				commerceShippingMethodId, shippingAddressId,
-				commerceOrder.getAdvanceStatus(),
-				commerceOrder.getCommercePaymentMethodKey(),
-				commerceOrder.getPurchaseOrderNumber(), shippingPrice,
-				shippingOptionName, commerceOrder.getSubtotal(),
-				commerceOrder.getTotal(), null);
+			commerceOrder = commerceOrderPersistence.update(commerceOrder);
+
+			Indexer<CommerceOrder> indexer =
+				IndexerRegistryUtil.nullSafeGetIndexer(CommerceOrder.class);
+
+			indexer.reindex(
+				CommerceOrder.class.getName(),
+				commerceOrder.getCommerceOrderId());
 		}
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -987,17 +987,30 @@ public class CommerceOrderLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public CommerceOrder resetCommerceOrderShipping(long commerceOrderId)
+	public CommerceOrder resetCommerceOrderShipping(CommerceOrder commerceOrder)
 		throws PortalException {
-
-		CommerceOrder commerceOrder =
-			commerceOrderLocalService.getCommerceOrder(commerceOrderId);
 
 		commerceOrder.setCommerceShippingMethodId(0);
 		commerceOrder.setShippingAmount(BigDecimal.ZERO);
 		commerceOrder.setShippingOptionName(null);
 
 		return commerceOrderPersistence.update(commerceOrder);
+	}
+
+	@Override
+	public void resetCommerceOrderShipping(long shippingAddressId)
+		throws PortalException {
+
+		if (shippingAddressId > 0) {
+			List<CommerceOrder> commerceOrders =
+				commerceOrderLocalService.getCommerceOrdersByShippingAddress(
+					shippingAddressId);
+
+			for (CommerceOrder commerceOrder : commerceOrders) {
+				commerceOrderLocalService.resetCommerceOrderShipping(
+					commerceOrder);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -906,6 +906,63 @@ public class CommerceOrderLocalServiceImpl
 		return commerceOrderPersistence.update(commerceOrder);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public CommerceOrder removeCommerceOrderBillingAddress(
+			CommerceOrder commerceOrder)
+		throws PortalException {
+
+		commerceOrder.setBillingAddressId(0);
+
+		return commerceOrderPersistence.update(commerceOrder);
+	}
+
+	@Override
+	public void removeCommerceOrderBillingAddress(long billingAddressId)
+		throws PortalException {
+
+		if (billingAddressId > 0) {
+			List<CommerceOrder> commerceOrders =
+				commerceOrderLocalService.getCommerceOrdersByBillingAddress(
+					billingAddressId);
+
+			for (CommerceOrder commerceOrder : commerceOrders) {
+				commerceOrderLocalService.removeCommerceOrderBillingAddress(
+					commerceOrder);
+			}
+		}
+	}
+
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public CommerceOrder removeCommerceOrderShippingAddress(
+			CommerceOrder commerceOrder)
+		throws PortalException {
+
+		commerceOrder.setCommerceShippingMethodId(0);
+		commerceOrder.setShippingAddressId(0);
+		commerceOrder.setShippingAmount(BigDecimal.ZERO);
+		commerceOrder.setShippingOptionName(null);
+
+		return commerceOrderPersistence.update(commerceOrder);
+	}
+
+	@Override
+	public void removeCommerceOrderShippingAddress(long shippingAddressId)
+		throws PortalException {
+
+		if (shippingAddressId > 0) {
+			List<CommerceOrder> commerceOrders =
+				commerceOrderLocalService.getCommerceOrdersByShippingAddress(
+					shippingAddressId);
+
+			for (CommerceOrder commerceOrder : commerceOrders) {
+				commerceOrderLocalService.removeCommerceOrderShippingAddress(
+					commerceOrder);
+			}
+		}
+	}
+
 	@Override
 	public CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId, CommerceContext commerceContext)

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -1572,7 +1572,6 @@ public class CommerceOrderLocalServiceImpl
 		return commerceOrderPersistence.update(commerceOrder);
 	}
 
-	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public CommerceOrder updateShippingAddress(
 			long commerceOrderId, String name, String description,

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -1581,11 +1581,16 @@ public class CommerceOrderLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		return updateAddress(
+		CommerceOrder commerceOrder = updateAddress(
 			commerceOrderId, name, description, street1, street2, street3, city,
 			zip, regionId, countryId, phoneNumber,
 			CommerceOrder::getShippingAddressId,
 			CommerceOrder::setShippingAddressId, serviceContext);
+
+		resetCommerceOrderShipping(commerceOrder.getShippingAddressId());
+
+		return commerceOrderPersistence.findByPrimaryKey(
+			commerceOrder.getCommerceOrderId());
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderServiceImpl.java
@@ -579,6 +579,20 @@ public class CommerceOrderServiceImpl extends CommerceOrderServiceBaseImpl {
 	}
 
 	@Override
+	public void resetCommerceOrderShipping(long commerceOrderId)
+		throws PortalException {
+
+		CommerceOrder commerceOrder =
+			commerceOrderLocalService.getCommerceOrder(commerceOrderId);
+
+		_commerceOrderModelResourcePermission.check(
+			getPermissionChecker(), commerceOrder, ActionKeys.UPDATE);
+
+		commerceOrderLocalService.resetCommerceOrderShipping(
+			commerceOrder.getShippingAddressId());
+	}
+
+	@Override
 	public CommerceOrder resetTermsAndConditions(
 			long commerceOrderId, boolean deliveryCommerceTermEntry,
 			boolean paymentCommerceTermEntry)

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
@@ -714,6 +714,12 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 			GetterUtil.get(
 				address.getPhoneNumber(), commerceAddress.getPhoneNumber()),
 			type, serviceContext);
+
+		_commerceOrderService.resetCommerceOrderShipping(
+			commerceOrder.getCommerceOrderId());
+
+		commerceOrder = _commerceOrderService.fetchCommerceOrder(
+			commerceOrder.getCommerceOrderId());
 	}
 
 	private void _updateOrder(CommerceOrder commerceOrder, Cart cart)


### PR DESCRIPTION
@tinatian, @dantewang.

This is just update.

In CommerceAddressLocalServiceImpl, there are two methods to use CommerceOrderLocalService. For now, I remove CommerceOrderLocalService from one method. I will run ci test in this pr and ask Summer to check if the current change worked next Monday.

