### PR TITLE
[LPS bug] LPS-159386 If request's parameter include the p_l_id (p_l_id >0) and …

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/LinkToPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/LinkToPageLayoutTypeController.java
@@ -122,7 +122,7 @@ public class LinkToPageLayoutTypeController
 	private static final String _URL =
 		"${liferay:mainPath}/portal/layout?p_v_l_s_g_id=${liferay:pvlsgid}&" +
 			"groupId=${liferay:groupId}&privateLayout=${privateLayout}&" +
-				"layoutId=${linkToLayoutId}";
+				"layoutId=${linkToLayoutId}&p_l_id=0";
 
 	@Reference
 	private ItemSelector _itemSelector;


### PR DESCRIPTION
…it is rendering LinkToPageLayout, we should always let request's parameter p_l_id is 0 based on the beginning logic of  Layouts (long plid = ParamUtil.getLong(httpServletRequest, "p_l_id")) in the ServicePreAction#_initThemeDisplay().