### PR TITLE
LPS-164385 Workaround fix to explain the root issue: Remove these cla…

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImpl.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImpl.java
@@ -86,7 +86,6 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  */
 @Component(
 	configurationPid = "com.liferay.portal.cluster.multiple.configuration.ClusterExecutorConfiguration",
-	enabled = false,
 	service = {ClusterExecutor.class, ClusterExecutorImpl.class}
 )
 public class ClusterExecutorImpl implements ClusterExecutor {
@@ -216,6 +215,12 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 
 	@Activate
 	protected void activate(ComponentContext componentContext) {
+		if (!GetterUtil.getBoolean(
+				_props.get(PropsKeys.CLUSTER_LINK_ENABLED))) {
+
+			return;
+		}
+
 		_enabled = true;
 
 		clusterExecutorConfiguration = ConfigurableUtil.createConfigurable(

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterLinkImpl.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterLinkImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,7 +45,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Shuyang Zhou
  */
-@Component(enabled = false, service = ClusterLink.class)
+@Component(service = ClusterLink.class)
 public class ClusterLinkImpl implements ClusterLink {
 
 	@Override
@@ -76,6 +77,12 @@ public class ClusterLinkImpl implements ClusterLink {
 
 	@Activate
 	protected void activate() {
+		if (!GetterUtil.getBoolean(
+				_props.get(PropsKeys.CLUSTER_LINK_ENABLED))) {
+
+			return;
+		}
+
 		_enabled = true;
 
 		initialize(

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannelFactory.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannelFactory.java
@@ -63,7 +63,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.portal.cluster.multiple.configuration.ClusterExecutorConfiguration",
-	enabled = false, service = ClusterChannelFactory.class
+	service = ClusterChannelFactory.class
 )
 public class JGroupsClusterChannelFactory implements ClusterChannelFactory {
 
@@ -100,6 +100,12 @@ public class JGroupsClusterChannelFactory implements ClusterChannelFactory {
 	@Modified
 	protected synchronized void activate(
 		BundleContext bundleContext, Map<String, Object> properties) {
+
+		if (!GetterUtil.getBoolean(
+				_props.get(PropsKeys.CLUSTER_LINK_ENABLED))) {
+
+			return;
+		}
 
 		_clusterExecutorConfiguration = ConfigurableUtil.createConfigurable(
 			ClusterExecutorConfiguration.class, properties);

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/portal/profile/ModulePortalProfile.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/portal/profile/ModulePortalProfile.java
@@ -14,11 +14,8 @@
 
 package com.liferay.portal.cluster.multiple.internal.portal.profile;
 
-import com.liferay.portal.cluster.multiple.internal.ClusterExecutorImpl;
-import com.liferay.portal.cluster.multiple.internal.ClusterLinkImpl;
 import com.liferay.portal.cluster.multiple.internal.ClusterMasterExecutorImpl;
 import com.liferay.portal.cluster.multiple.internal.ClusterMasterTokenTransitionListenerTracker;
-import com.liferay.portal.cluster.multiple.internal.jgroups.JGroupsClusterChannelFactory;
 import com.liferay.portal.kernel.cluster.ClusterExecutor;
 import com.liferay.portal.kernel.cluster.ClusterLink;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
@@ -115,9 +112,6 @@ public class ModulePortalProfile extends BaseDSModulePortalProfile {
 
 		init(
 			componentContext, supportedPortalProfileNames,
-			JGroupsClusterChannelFactory.class.getName(),
-			ClusterExecutorImpl.class.getName(),
-			ClusterLinkImpl.class.getName(),
 			ClusterMasterExecutorImpl.class.getName(),
 			ClusterMasterTokenTransitionListenerTracker.class.getName());
 	}


### PR DESCRIPTION
…sses from ModulePortalProfile. Since ModulePortalProfile will invoke componentContext.enableComponent(componentName) api from "Start Level: Equinox Container" thread and it will use another "SCR Component Actor" thread to activate ClusterExecutorImpl and ClusterLinkImpl components. At this time, "Start Level: Equinox Container" thread won't wait "SCR Component Actor" thread finished and it will continue to execute. The issue happens when "Start Level: Equinox Container" thread finished and then it back to Main thread(ModuleFrameworkImpl#_startDynamicBundles() {FrameworkEvent frameworkEvent = defaultNoticeableFuture.get() // 1646 line}), Main thread continues to execute. But "SCR Component Actor" thread doesn't finish creating the two channels since the configuration used long times(join_timeout:30s) to wait. The workaround avoid using componentContext.enableComponent(componentName) api to activate the components, and the activate() methods will be finished in the "Start Level: Equinox Container" thread.