### PR TITLE
LPS-195673 After upgrading portal from 7.1 to master, the sql "SELECT…

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1219,6 +1219,10 @@ public class ResourcePermissionLocalServiceImpl
 
 			validate(modelResource, false);
 
+			if (modelResource.equals("com.liferay.bookmarks")) {
+				System.out.println("test");
+			}
+
 			List<String> groupModelActionIds = null;
 
 			if (Objects.equals(rootModelResource, modelResource)) {


### PR DESCRIPTION
… * FROM ResourcePermission where name ='com.liferay.bookmarks" won't return any rows. And then adding the breakpoint in the if block, startup bundle, two threads will go to this line. The two threads are deploying com_liferay_bookmarks_web_portlet_BookmarksAdminPortlet and com_liferay_bookmarks_web_portlet_BookmarksPortlet. The error "HHH000315: Exception executing batch [java.sql.BatchUpdateException: Duplicate entry '20099-4-com.liferay.bookmarks-com.liferay.bookmarks-20115-0' for key 'IX_F2237D8E'" will happen.